### PR TITLE
Script was failing when checking PS-5.5 on Debian/Ubuntu because version

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -94,6 +94,7 @@ if [ ${product} = "ps55" -o ${product} = "ps56" -o ${product} = "ps57" ]; then
   else
     deb_maj_version=$(echo ${product} | sed 's/^[a-z]*//' | sed 's/./&\./') # 5.6
     if [ ${product} = "ps55" ]; then
+      version=$(echo ${version} | sed 's/-/-rel/') # 5.5.53-rel38.5
       deb_opt_package=""
       deb_num_pkgs="6"
     else


### PR DESCRIPTION
name is different than for 5.6 and 5.7 (it has additional "rel" similar
to CentOS packages).