### PR TITLE
Fix molecule install

### DIFF
--- a/molecule/JenkinsfilePS
+++ b/molecule/JenkinsfilePS
@@ -57,12 +57,15 @@ ubuntu-bionic'''
         }
         checkout scm
         withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', accessKeyVariable: 'AWS_ACCESS_KEY_ID', credentialsId: 'AMI/OVF', secretKeyVariable: 'AWS_SECRET_ACCESS_KEY']]) {
-          sh '''#!/bin/bash
+          sh '''#!/bin/bash -e
+              echo 'Installing dependencies'
               sudo yum install -y gcc python3-pip python3-devel libselinux-python openssl-devel
               sudo mkdir -p /usr/local/lib64/python3.7/site-packages
               sudo rsync -aHv /usr/lib64/python2.7/site-packages/*selinux* /usr/local/lib64/python3.7/site-packages/
               pip3 install --user pytest molecule==2.22 ansible wheel boto boto3 paramiko selinux 'molecule[ec2]'
+          '''
 
+          sh '''#!/bin/bash
               # remove this because otherwise molecule will fail to validate
               rm -f molecule/${ROLE_NAME}/molecule/default/molecule.yml
 

--- a/molecule/JenkinsfilePS
+++ b/molecule/JenkinsfilePS
@@ -62,6 +62,7 @@ ubuntu-bionic'''
               sudo yum install -y gcc python3-pip python3-devel libselinux-python openssl-devel
               sudo mkdir -p /usr/local/lib64/python3.7/site-packages
               sudo rsync -aHv /usr/lib64/python2.7/site-packages/*selinux* /usr/local/lib64/python3.7/site-packages/
+              pip3 install --user --upgrade pip setuptools
               pip3 install --user pytest molecule==2.22 ansible wheel boto boto3 paramiko selinux 'molecule[ec2]'
           '''
 

--- a/molecule/JenkinsfilePS
+++ b/molecule/JenkinsfilePS
@@ -62,8 +62,8 @@ ubuntu-bionic'''
               sudo yum install -y gcc python3-pip python3-devel libselinux-python openssl-devel
               sudo mkdir -p /usr/local/lib64/python3.7/site-packages
               sudo rsync -aHv /usr/lib64/python2.7/site-packages/*selinux* /usr/local/lib64/python3.7/site-packages/
-              pip3 install --user --upgrade pip setuptools
-              pip3 install --user pytest molecule==2.22 ansible wheel boto boto3 paramiko selinux 'molecule[ec2]'
+              python3 -m pip install --user --upgrade pip setuptools
+              python3 -m pip install --user pytest molecule==2.22 ansible wheel boto boto3 paramiko selinux 'molecule[ec2]'
           '''
 
           sh '''#!/bin/bash


### PR DESCRIPTION
This fixes the issues with molecule installation in the `test-ps-pkg` job. It does not fix the job itself, though; molecule now runs, but it seems to fail due to other reasons. Compare outputs of builds [#160](https://ps80.cd.percona.com/view/QA/job/test-ps-pkg/160) and [#171](https://ps80.cd.percona.com/view/QA/job/test-ps-pkg/171).