### PR TITLE
Use Jinja2 templates to interpolate dynamic platform list

### DIFF
--- a/molecule/JenkinsfilePS
+++ b/molecule/JenkinsfilePS
@@ -63,52 +63,20 @@ ubuntu-bionic'''
               sudo mkdir -p /usr/local/lib64/python3.7/site-packages
               sudo rsync -aHv /usr/lib64/python2.7/site-packages/*selinux* /usr/local/lib64/python3.7/site-packages/
               python3 -m pip install --user --upgrade pip setuptools
-              python3 -m pip install --user pytest molecule==2.22 ansible wheel boto boto3 paramiko selinux 'molecule[ec2]'
+              python3 -m pip install --user pytest molecule==2.22 ansible wheel boto boto3 paramiko selinux 'molecule[ec2]' 'j2cli[yaml]'
           '''
 
           sh '''#!/bin/bash
               # remove this because otherwise molecule will fail to validate
               rm -f molecule/${ROLE_NAME}/molecule/default/molecule.yml
 
-              REPLACE_STRING="##PLATFORM_PLACEHOLDER##"
-              MOLECULE_FILE="molecule/${ROLE_NAME}/molecule/ec2/molecule.yml"
-              #
-              PS_56_INSTALL_DIST=(debian-8 debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_57_INSTALL_DIST=(debian-8 debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_57_UPGRADE_DIST=(debian-8 debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_57_MAJ_UPGRADE_TO_DIST=(debian-8 debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_57_MAJ_UPGRADE_FROM_DIST=(debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_80_INSTALL_DIST=(debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_80_UPGRADE_DIST=(debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              PS_80_MAJ_UPGRADE_TO_DIST=(debian-9 debian-10 centos-6 centos-7 ubuntu-xenial ubuntu-bionic amazonlinux-2)
-              #
-              ROLE_DIST="${ROLE_NAME//-/_}"
-              ROLE_DIST="${ROLE_DIST^^}_DIST[@]"
-              for PLATFORM in ${PLATFORMS}; do
-                if [[ " ${!ROLE_DIST} " =~ " ${PLATFORM} " ]]; then
-                  PL_PARAMS=$(grep -A6 "${PLATFORM}:" molecule/configuration.yml)
-                  AWS_DEFAULT_REGION=$(echo "${PL_PARAMS}" | grep "aws_default_region:"|awk -F': ' '{print $2}' )
-                  IMAGE=$(echo "${PL_PARAMS}" | grep "image:"|awk -F': ' '{print $2}' )
-                  SUBNET=$(echo "${PL_PARAMS}" | grep "subnet:"|awk -F': ' '{print $2}' )
-                  INSTANCE_TYPE=$(echo "${PL_PARAMS}" | grep "instance_type:"|awk -F': ' '{print $2}' )
-                  ROOT_DEVICE_NAME=$(echo "${PL_PARAMS}" | grep "root_device_name:"|awk -F': ' '{print $2}' )
-                  USER=$(echo "${PL_PARAMS}" | grep "user:"|awk -F': ' '{print $2}' )
-                  #
-                  sed -i "s/${REPLACE_STRING}/  - name: ${ROLE_NAME}-${PLATFORM}\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/    region: ${AWS_DEFAULT_REGION}\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/    image: ${IMAGE}\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/    vpc_subnet_id: ${SUBNET}\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/    instance_type: ${INSTANCE_TYPE}\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s!${REPLACE_STRING}!    root_device_name: ${ROOT_DEVICE_NAME}\\n${REPLACE_STRING}!" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/    ssh_user: ${USER}\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/    instance_tags:\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                  sed -i "s/${REPLACE_STRING}/      iit-billing-tag: jenkins-ps-pkg-worker\\n${REPLACE_STRING}/" ${MOLECULE_FILE}
-                else
-                  echo "##### Skipping ${PLATFORM} since not supported by role ${ROLE_NAME} #####"
-                fi
-              done
+              TEMPLATE="molecule/${ROLE_NAME}/molecule/ec2/molecule.yml.j2"
+              TEMPLATE_OUTFILE="molecule/${ROLE_NAME}/molecule/ec2/molecule.yml"
+              TEMPLATE_CONFIGURATION="molecule/configuration.yml"
+              j2 -f yaml $TEMPLATE $TEMPLATE_CONFIGURATION > $TEMPLATE_OUTFILE
+              
               echo "##### MOLECULE FILE CONTENT #####"
-              cat ${MOLECULE_FILE}
+              cat ${TEMPLATE_OUTFILE}
               echo "#########################"
               cd molecule/${ROLE_NAME}
               python3 -m molecule list

--- a/molecule/JenkinsfilePsmdbPackages
+++ b/molecule/JenkinsfilePsmdbPackages
@@ -74,13 +74,13 @@ pipeline {
     stage ('Setup Environment Variables') {
       steps {
        script {
-       vms = readYaml (file: 'molecule/configuration.yml')
-       env.IMAGE = vms."${PLATFORM}".image
-       env.USER = vms."${PLATFORM}".user
-       env.SUBNET = vms."${PLATFORM}".subnet
-       env.AWS_DEFAULT_REGION = vms."${PLATFORM}".aws_default_region
-       env.INSTANCE_TYPE = vms."${PLATFORM}".instance_type
-       env.ROOT_DEVICE_NAME = vms."${PLATFORM}".root_device_name
+       config = readYaml (file: 'molecule/configuration.yml')
+       env.IMAGE = config.vms."${PLATFORM}".image
+       env.USER = config.vms."${PLATFORM}".user
+       env.SUBNET = config.vms."${PLATFORM}".subnet
+       env.AWS_DEFAULT_REGION = config.vms."${PLATFORM}".aws_default_region
+       env.INSTANCE_TYPE = config.vms."${PLATFORM}".instance_type
+       env.ROOT_DEVICE_NAME = config.vms."${PLATFORM}".root_device_name
         }
        }
       }

--- a/molecule/configuration.yml
+++ b/molecule/configuration.yml
@@ -1,91 +1,116 @@
-centos-6:
-  image: ami-07fa74e425f2abf29
-  user: centos
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-centos-7:
-  image: ami-04cf43aca3e6f3de3
-  user: centos
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-centos-8:
-  image: ami-0034c84e4e9c557bd
-  user: centos
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-debian-8:
-  image: ami-abff2ac4
-  user: admin
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/xvda
-debian-9:
-  image: ami-006c08e13f35edce0
-  user: admin
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: xvda
-debian-10:
-  image: ami-0be88f8d647409e61
-  user: admin
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: xvda
-ubuntu-cosmic:
-  image: ami-0ead033d778487b37
-  user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-ubuntu-disco:
-  image: ami-084a12ae4a0c27ea7
-  user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-ubuntu-bionic:
-  image: ami-0a8561d8c5a4f098a
-  user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-ubuntu-xenial:
-  image: ami-44182caf
-  user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-ubuntu-focal:
-  image: ami-00ffef8efdbc08528
-  user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-rhel8:
-  image: ami-0badcc5b522737046
-  user: ec2-user
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/sda1
-amazonlinux-2:
-  image: ami-074dc9dd588b6ea52
-  user: ec2-user
-  subnet: subnet-085deaca8c1c59a4f
-  aws_default_region: eu-central-1
-  instance_type: t2.micro
-  root_device_name: /dev/xvda
+roles:
+  ps-56-install: &5x_vms
+    - debian-8
+    - debian-9
+    - debian-10
+    - centos-6
+    - centos-7
+    - ubuntu-xenial
+    - ubuntu-bionic
+    - amazonlinux-2
+  ps-57-install: *5x_vms
+  ps-57-upgrade: *5x_vms
+  ps-57-maj-upgrade-to: *5x_vms
+  ps-57-maj-upgrade-from: &8x_vms
+    - debian-9
+    - debian-10
+    - centos-6
+    - centos-7
+    - ubuntu-xenial
+    - ubuntu-bionic
+    - amazonlinux-2
+  ps-80-install: *8x_vms
+  ps-80-upgrade: *8x_vms
+  ps-80-maj-upgrade-to: *8x_vms
+vms:
+  centos-6:
+    image: ami-07fa74e425f2abf29
+    user: centos
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  centos-7:
+    image: ami-04cf43aca3e6f3de3
+    user: centos
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  centos-8:
+    image: ami-0034c84e4e9c557bd
+    user: centos
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  debian-8:
+    image: ami-abff2ac4
+    user: admin
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/xvda
+  debian-9:
+    image: ami-006c08e13f35edce0
+    user: admin
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: xvda
+  debian-10:
+    image: ami-0be88f8d647409e61
+    user: admin
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: xvda
+  ubuntu-cosmic:
+    image: ami-0ead033d778487b37
+    user: ubuntu
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  ubuntu-disco:
+    image: ami-084a12ae4a0c27ea7
+    user: ubuntu
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  ubuntu-bionic:
+    image: ami-0a8561d8c5a4f098a
+    user: ubuntu
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  ubuntu-xenial:
+    image: ami-44182caf
+    user: ubuntu
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  ubuntu-focal:
+    image: ami-00ffef8efdbc08528
+    user: ubuntu
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  rhel8:
+    image: ami-0badcc5b522737046
+    user: ec2-user
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/sda1
+  amazonlinux-2:
+    image: ami-074dc9dd588b6ea52
+    user: ec2-user
+    subnet: subnet-085deaca8c1c59a4f
+    aws_default_region: eu-central-1
+    instance_type: t2.micro
+    root_device_name: /dev/xvda

--- a/molecule/ps-56-install/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-56-install/molecule/ec2/molecule.yml.j2
@@ -22,23 +22,26 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-56-install" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
-    cleanup: ../../../ps-80-install/molecule/default/cleanup.yml
+    cleanup: ../default/cleanup.yml
     destroy: ../../../playbooks/destroy.yml
     prepare: ../../../playbooks/prepare.yml
   lint:
@@ -46,7 +49,7 @@ provisioner:
     enabled: False
 verifier:
   name: testinfra
-  directory: ../../../ps-80-install/molecule/default/tests
+  directory: ../default/tests
   options:
     verbose: true
     s: true

--- a/molecule/ps-57-install/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-57-install/molecule/ec2/molecule.yml.j2
@@ -22,23 +22,26 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-57-install" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
-    cleanup: ../../../ps-80-install/molecule/default/cleanup.yml
+    cleanup: ../default/cleanup.yml
     destroy: ../../../playbooks/destroy.yml
     prepare: ../../../playbooks/prepare.yml
   lint:
@@ -46,7 +49,7 @@ provisioner:
     enabled: False
 verifier:
   name: testinfra
-  directory: ../../../ps-80-install/molecule/default/tests
+  directory: ../default/tests
   options:
     verbose: true
     s: true

--- a/molecule/ps-57-maj-upgrade-from/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-57-maj-upgrade-from/molecule/ec2/molecule.yml.j2
@@ -22,20 +22,23 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-57-maj-upgrade-from" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
     cleanup: ../../../ps-80-install/molecule/default/cleanup.yml

--- a/molecule/ps-57-maj-upgrade-to/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-57-maj-upgrade-to/molecule/ec2/molecule.yml.j2
@@ -22,20 +22,23 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-57-maj-upgrade-to" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
     cleanup: ../../../ps-57-install/molecule/default/cleanup.yml

--- a/molecule/ps-57-upgrade/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-57-upgrade/molecule/ec2/molecule.yml.j2
@@ -22,20 +22,23 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-57-upgrade" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
     cleanup: ../../../ps-57-install/molecule/default/cleanup.yml

--- a/molecule/ps-80-install/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-80-install/molecule/ec2/molecule.yml.j2
@@ -22,20 +22,23 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-80-install" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
     cleanup: ../default/cleanup.yml

--- a/molecule/ps-80-maj-upgrade-to/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-80-maj-upgrade-to/molecule/ec2/molecule.yml.j2
@@ -22,23 +22,26 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-80-maj-upgrade-to" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
-    cleanup: ../default/cleanup.yml
+    cleanup: ../../../ps-80-install/molecule/default/cleanup.yml
     destroy: ../../../playbooks/destroy.yml
     prepare: ../../../playbooks/prepare.yml
   lint:
@@ -46,7 +49,7 @@ provisioner:
     enabled: False
 verifier:
   name: testinfra
-  directory: ../default/tests
+  directory: ../../../ps-80-install/molecule/default/tests
   options:
     verbose: true
     s: true

--- a/molecule/ps-80-upgrade/molecule/ec2/molecule.yml.j2
+++ b/molecule/ps-80-upgrade/molecule/ec2/molecule.yml.j2
@@ -22,23 +22,26 @@ driver:
 lint:
   name: yamllint
 platforms:
-##PLATFORM_PLACEHOLDER##
-#  - name: ps80-pkg-install-${PLATFORM}
-#    region: ${AWS_DEFAULT_REGION}
-#    image: ${IMAGE}
-#    vpc_subnet_id: ${SUBNET}
-#    instance_type: ${INSTANCE_TYPE}
-#    root_device_name: ${ROOT_DEVICE_NAME}
-#    ssh_user: ${USER}
-#    instance_tags:
-#      iit-billing-tag: jenkins-ps-pkg-worker
+{%- set role = "ps-80-upgrade" %}
+{%- set platforms = env("PLATFORMS").split() %}
+{%- for platform, vm in vms.items() if platform in roles[role] and platform in platforms %}
+  - name: {{role}}-{{platform}}
+    region: {{vm.aws_default_region}}
+    image: {{vm.image}}
+    vpc_subnet_id: {{vm.subnet}}
+    instance_type: {{vm.instance_type}}
+    root_device_name: {{vm.root_device_name}}
+    ssh_user: {{vm.user}}
+    instance_tags:
+      iit-billing-tag: jenkins-ps-pkg-worker
+{%- endfor %}
 provisioner:
   name: ansible
   env:
-    MOLECULE_KEY_NAME: molecule-${ROLE_NAME}
+    MOLECULE_KEY_NAME: molecule-{{role}}
   playbooks:
     create: ../../../playbooks/create.yml
-    cleanup: ../default/cleanup.yml
+    cleanup: ../../../ps-80-install/molecule/default/cleanup.yml
     destroy: ../../../playbooks/destroy.yml
     prepare: ../../../playbooks/prepare.yml
   lint:
@@ -46,7 +49,7 @@ provisioner:
     enabled: False
 verifier:
   name: testinfra
-  directory: ../default/tests
+  directory: ../../../ps-80-install/molecule/default/tests
   options:
     verbose: true
     s: true


### PR DESCRIPTION
This replaces the existing sed-based interpolation within `JenkinsfilePS` with Jinja2 templates, using [j2cli](https://github.com/kolypto/j2cli) to compile them. This moves the bash logic previously embedded in the Jenkinsfile to the templates and the configuration file that feeds it. The templates require the PLATFORMS environment variable to be compiled (will error if missing), but not the ROLE_NAME environment variable, which is now only a concern of the Jenkinsfile.

This should make it a bit easier to run it locally, as compiling the templates only requires one not-too-complex invocation of `j2`, which could be extracted to a separate script if needed.