### PR TITLE
Setup keyring vault locally in PS playbooks

### DIFF
--- a/playbooks/common_57.yml
+++ b/playbooks/common_57.yml
@@ -10,24 +10,18 @@
 - hosts: all
   become: true
   become_method: sudo
-  vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
 
   tasks:
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: include tasks for enabling test repo
     include: ../tasks/enable_testing_repo.yml
@@ -96,7 +90,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps57
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: re-run ps_admin to install rocksdb
     command: /usr/bin/ps-admin --enable-rocksdb

--- a/playbooks/common_57_major_upgrade_from.yml
+++ b/playbooks/common_57_major_upgrade_from.yml
@@ -13,8 +13,6 @@
   become: true
   become_method: sudo
   vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
     major_upgrade: true
 
   tasks:
@@ -22,16 +20,13 @@
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: include tasks for enabling test repo
     include: ../tasks/enable_testing_repo.yml
@@ -263,7 +258,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps80
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: run bats unit tests for ps-admin script
     command: /usr/local/bin/bats /package-testing/bats/ps-admin_unit.bats

--- a/playbooks/common_57_major_upgrade_to.yml
+++ b/playbooks/common_57_major_upgrade_to.yml
@@ -12,8 +12,6 @@
   become: true
   become_method: sudo
   vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
     major_upgrade: true
 
   tasks:
@@ -271,16 +269,13 @@
         THP_SETTING=never
     when: (ansible_distribution == "Amazon") or (ansible_os_family == "RedHat" and ansible_distribution_major_version >= "7")
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: remove mysql package on centos 8
     yum:
@@ -334,7 +329,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps57
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: run ps_admin to install rocksdb
     command: /usr/bin/ps-admin --enable-rocksdb

--- a/playbooks/common_57_upgrade.yml
+++ b/playbooks/common_57_upgrade.yml
@@ -12,9 +12,6 @@
 - hosts: all
   become: true
   become_method: sudo
-  vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
 
   tasks:
   - name: include tasks for test env setup
@@ -26,16 +23,13 @@
   - name: include tasks for enabling main repo
     include: ../tasks/enable_main_repo.yml
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -169,7 +163,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps57
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: check that Percona XtraBackup version is correct
     command: /package-testing/version_check.sh pxb24

--- a/playbooks/ps_80.yml
+++ b/playbooks/ps_80.yml
@@ -10,24 +10,18 @@
 - hosts: all
   become: true
   become_method: sudo
-  vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
 
   tasks:
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: enforce SELinux on CentOS
     selinux:
@@ -118,7 +112,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps80
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: re-run ps_admin to install rocksdb
     command: /usr/bin/ps-admin --enable-rocksdb

--- a/playbooks/ps_80_major_upgrade_to.yml
+++ b/playbooks/ps_80_major_upgrade_to.yml
@@ -13,8 +13,6 @@
   become: true
   become_method: sudo
   vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
     major_upgrade: true
 
   tasks:
@@ -22,16 +20,13 @@
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: include tasks for enabling test repo
     include: ../tasks/enable_testing_repo.yml
@@ -100,7 +95,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps57
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: re-run ps_admin to install rocksdb
     command: /usr/bin/ps-admin --enable-rocksdb
@@ -262,7 +256,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps80
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: run bats unit tests for ps-admin script
     command: /usr/local/bin/bats /package-testing/bats/ps-admin_unit.bats

--- a/playbooks/ps_80_upgrade.yml
+++ b/playbooks/ps_80_upgrade.yml
@@ -12,24 +12,18 @@
 - hosts: all
   become: true
   become_method: sudo
-  vars:
-    vault_token: "{{ lookup('env', 'VAULT_TEST_TOKEN') }}"
-    vault_cert: "{{ lookup('env', 'VAULT_TEST_CERT') }}"
 
   tasks:
   - name: include tasks for test env setup
     include: ../tasks/test_prep.yml
 
+  - name: include tasks for local vault setup
+    include_tasks: ../tasks/setup_local_vault.yml
+
   - name: setup config file for keyring vault
-    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+    template: src=../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
               dest=/package-testing/scripts/ps_keyring_plugins_test/keyring_vault_test.cnf
               mode=0664 owner=root group=root
-
-  - name: copy certificate for keyring vault
-    copy:
-      src: "{{ vault_cert }}"
-      dest: /package-testing/scripts/ps_keyring_plugins_test/test.cer
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
 # Install from main repository
 
@@ -241,7 +235,6 @@
 
   - name: keyring plugins test
     command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps80
-    when: lookup('env', 'PS_SKIP_KEYRING') == "" or lookup('env', 'PS_SKIP_KEYRING') == "0"
 
   - name: check that Percona XtraBackup version is correct
     command: /package-testing/version_check.sh pxb80

--- a/scripts/ps_keyring_plugins_test/keyring_vault_test.j2
+++ b/scripts/ps_keyring_plugins_test/keyring_vault_test.j2
@@ -1,4 +1,0 @@
-vault_url = https://10.30.6.213:8200
-secret_mount_point = secret
-token = {{ vault_token }}
-vault_ca = /package-testing/scripts/ps_keyring_plugins_test/test.cer


### PR DESCRIPTION
This PR changes the `ps_80*.yml` and `common_57*.yml` playbooks so that they use the existing `setup_local_vault.yml` tasks from the molecule jobs to launch a local instance of Vault.

This is in opposition to the previous behaviour of connecting to a pre-existing Vault server, which is accessible from the old Jenkins instance's internal network, but isn't accessible from the new Jenkins instances. The purpose of this change is to make it possible to run these playbooks on the new Jenkins, but it should work just fine on the existing jobs that run them in the old Jenkins.

Since the playbook now launches its own Vault, without depending on Jenkins-provided credentials for the certificates or internal network access, there is no need to skip keyring-related steps when running it locally, so all references to the PS_SKIP_KEYRING environment variable have been removed. It also removes the `keyring_vault_test.j2` configuration template, which hardcoded the IP address of the pre-existing Vault server and is now unused.

I have tested this locally on Vagrant with the `ps_80.yml` playbook, using Ubuntu Bionic and Centos 8.