### PR TITLE
Fix PXC 5.7 binary tarball tests

### DIFF
--- a/binary-tarball-tests/pxc/Vagrantfile
+++ b/binary-tarball-tests/pxc/Vagrantfile
@@ -1,0 +1,46 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/centos8"
+  
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    ### 5.7
+    export PXC_VERSION=5.7.33-31.49
+    export PXC_REVISION=a1ed9c3
+    export WSREP_VERSION=31.49
+    export PXC57_PKG_VERSION=5.7.33-rel36-49.1
+
+    ### 8.0
+    # export PXC_VERSION=8.0.22-13.1
+    # export PXC_REVISION=a48e6d5
+    # export WSREP_VERSION=26.4.3
+    # export PXC57_PKG_VERSION=5.7.33-rel36-49.1
+
+    echo ${BUILD_TYPE_MINIMAL}
+    PXC_MAJOR_VERSION="$(echo ${PXC_VERSION}|cut -d'.' -f1,2)"
+    MINIMAL=""
+    if [ "${BUILD_TYPE_MINIMAL}" = "true" ]; then
+      MINIMAL="-minimal"
+    fi
+    if [ "${PXC_MAJOR_VERSION}" = "8.0" ]; then
+      TARBALL_NAME="Percona-XtraDB-Cluster_${PXC_VERSION}_Linux.x86_64.glibc2.17${MINIMAL}.tar.gz"
+      TARBALL_LINK="https://downloads.percona.com/downloads/TESTING/pxc-${PXC_VERSION}/"
+    elif [ "${PXC_MAJOR_VERSION}" = "5.7" ]; then
+      TARBALL_NAME="Percona-XtraDB-Cluster-${PXC57_PKG_VERSION}.Linux.x86_64.glibc2.17${MINIMAL}.tar.gz"
+      TARBALL_LINK="https://downloads.percona.com/downloads/TESTING/pxc-${PXC_VERSION}/"
+    fi
+    rm -rf package-testing
+    if [ -f /usr/bin/yum ]; then
+      sudo yum install -y git wget
+      sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+      sudo yum install -y percona-xtrabackup-24
+    else
+      sudo apt install -y git wget
+    fi
+    git clone https://github.com/Percona-QA/package-testing.git --branch fix-pxc-57-binary-tarball --depth 1
+    cd package-testing/binary-tarball-tests/pxc
+    wget -q ${TARBALL_LINK}${TARBALL_NAME}
+    ./run.sh || true
+  SHELL
+end

--- a/binary-tarball-tests/pxc/Vagrantfile
+++ b/binary-tarball-tests/pxc/Vagrantfile
@@ -33,8 +33,6 @@ Vagrant.configure("2") do |config|
     rm -rf package-testing
     if [ -f /usr/bin/yum ]; then
       sudo yum install -y git wget
-      sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
-      sudo yum install -y percona-xtrabackup-24
     else
       sudo apt install -y git wget
     fi

--- a/binary-tarball-tests/pxc/mysql.py
+++ b/binary-tarball-tests/pxc/mysql.py
@@ -98,15 +98,6 @@ class MySQL:
         self.stop()
         self.start()
 
-    def purge(self):
-        self.stop()
-        subprocess.call(['rm', '-Rf', self.node1_datadir])
-        subprocess.call(['rm', '-Rf', self.node2_datadir])
-        subprocess.call(['rm', '-Rf', self.node3_datadir])
-        subprocess.call(['rm', '-f', self.node1_logfile])
-        subprocess.call(['rm', '-f', self.node2_logfile])
-        subprocess.call(['rm', '-f', self.node3_logfile])
-
     def run_query(self,query,node="node1"):
         node_sockets = {
             "node1": self.node1_socket,

--- a/binary-tarball-tests/pxc/mysql.py
+++ b/binary-tarball-tests/pxc/mysql.py
@@ -103,7 +103,6 @@ class MySQL:
         subprocess.check_call([self.mysqladmin, '-uroot', '-S'+self.node3_socket, 'shutdown'])
         subprocess.check_call([self.mysqladmin, '-uroot', '-S'+self.node2_socket, 'shutdown'])
         subprocess.check_call([self.mysqladmin, '-uroot', '-S'+self.node1_socket, 'shutdown'])
-        subprocess.call(['sleep', '5'])
 
     def restart(self):
         self.stop()

--- a/binary-tarball-tests/pxc/mysql.py
+++ b/binary-tarball-tests/pxc/mysql.py
@@ -123,11 +123,3 @@ class MySQL:
         query = 'SELECT plugin_status FROM information_schema.plugins WHERE plugin_name = "{}";'.format(pname)
         output = self.run_query(query, node="node3")
         assert 'ACTIVE' in output
-
-    def check_engine_active(self, engine):
-        query = '"select SUPPORT from information_schema.ENGINES where ENGINE = \\\"{}\\\";"'.format(engine)
-        output = self.run_query(query)
-        if 'YES' in output:
-            return True
-        else:
-            return False

--- a/binary-tarball-tests/pxc/mysql.py
+++ b/binary-tarball-tests/pxc/mysql.py
@@ -3,6 +3,7 @@ import subprocess
 import re
 import os
 import time
+import shlex
 
 class MySQL:
     def __init__(self, base_dir):
@@ -106,20 +107,20 @@ class MySQL:
         }
         socket = node_sockets[node]
 
-        command = self.mysql+' --user=root -S'+socket+' -s -N -e '+query
+        command = self.mysql+' --user=root -S'+socket+' -s -N -e '+shlex.quote(query)
         return subprocess.check_output(command, shell=True, universal_newlines=True)
 
     def install_function(self, fname, soname, return_type):
-        query = '"CREATE FUNCTION {} RETURNS {} SONAME \\\"{}\\\";"'.format(fname, return_type, soname)
+        query = 'CREATE FUNCTION {} RETURNS {} SONAME "{}";'.format(fname, return_type, soname)
         self.run_query(query)
-        query = '"SELECT name FROM mysql.func WHERE dl = \\\"{}\\\";"'.format(soname)
+        query = 'SELECT name FROM mysql.func WHERE dl = "{}";'.format(soname)
         output = self.run_query(query, node="node2")
         assert fname in output
 
     def install_plugin(self, pname, soname):
-        query = '"INSTALL PLUGIN {} SONAME \\\"{}\\\";"'.format(pname,soname)
+        query = 'INSTALL PLUGIN {} SONAME "{}";'.format(pname,soname)
         self.run_query(query)
-        query = '"SELECT plugin_status FROM information_schema.plugins WHERE plugin_name = \\\"{}\\\";"'.format(pname)
+        query = 'SELECT plugin_status FROM information_schema.plugins WHERE plugin_name = "{}";'.format(pname)
         output = self.run_query(query, node="node3")
         assert 'ACTIVE' in output
 

--- a/binary-tarball-tests/pxc/mysql.py
+++ b/binary-tarball-tests/pxc/mysql.py
@@ -107,22 +107,29 @@ class MySQL:
         subprocess.call(['rm', '-f', self.node2_logfile])
         subprocess.call(['rm', '-f', self.node3_logfile])
 
-    def run_query(self,query):
-        command = self.mysql+' --user=root -S'+self.node1_socket+' -s -N -e '+query
+    def run_query(self,query,node="node1"):
+        node_sockets = {
+            "node1": self.node1_socket,
+            "node2": self.node2_socket,
+            "node3": self.node3_socket,
+        }
+        socket = node_sockets[node]
+
+        command = self.mysql+' --user=root -S'+socket+' -s -N -e '+query
         return subprocess.check_output(command, shell=True, universal_newlines=True)
 
     def install_function(self, fname, soname, return_type):
         query = '"CREATE FUNCTION {} RETURNS {} SONAME \\\"{}\\\";"'.format(fname, return_type, soname)
         self.run_query(query)
         query = '"SELECT name FROM mysql.func WHERE dl = \\\"{}\\\";"'.format(soname)
-        output = self.run_query(query)
+        output = self.run_query(query, node="node2")
         assert fname in output
 
     def install_plugin(self, pname, soname):
         query = '"INSTALL PLUGIN {} SONAME \\\"{}\\\";"'.format(pname,soname)
         self.run_query(query)
         query = '"SELECT plugin_status FROM information_schema.plugins WHERE plugin_name = \\\"{}\\\";"'.format(pname)
-        output = self.run_query(query)
+        output = self.run_query(query, node="node3")
         assert 'ACTIVE' in output
 
     def check_engine_active(self, engine):

--- a/binary-tarball-tests/pxc/mysql.py
+++ b/binary-tarball-tests/pxc/mysql.py
@@ -37,9 +37,9 @@ class MySQL:
         x = re.search(r"[0-9]+\.[0-9]+", output)
         self.major_version = x.group()
         if self.major_version != "8.0":
-            self.sst_opts = "--wsrep_sst_method=xtrabackup-v2 --wsrep_sst_auth=root:"
+            self.sst_opts = ["--wsrep_sst_method=xtrabackup-v2", "--wsrep_sst_auth=root:"]
         else:
-            self.sst_opts = "--wsrep_sst_method=xtrabackup-v2"
+            self.sst_opts = ["--wsrep_sst_method=xtrabackup-v2"]
         if self.major_version == "5.6":
             subprocess.check_call([self.mysql_install_db, '--no-defaults', '--basedir=' + self.basedir,
                                    '--datadir='+ self.node1_datadir])
@@ -70,21 +70,21 @@ class MySQL:
                           '--datadir=' + self.node1_datadir,
                           '--tmpdir=' + self.node1_datadir, '--socket=' + self.node1_socket,
                           '--log-error=' + self.node1_logfile, '--wsrep_provider=' + self.wsrep_provider,
-                          self.sst_opts, '--wsrep-new-cluster'], env=os.environ)
+                          *self.sst_opts, '--wsrep-new-cluster'], env=os.environ)
         self.startup_check(self.node1_socket)
         os.system("cat " + self.node1_logfile)
         subprocess.Popen([self.mysqld, '--defaults-file=' + self.node2_cnf, '--basedir=' + self.basedir,
                           '--datadir=' + self.node2_datadir,
                           '--tmpdir=' + self.node2_datadir, '--socket=' + self.node2_socket,
                           '--log-error=' + self.node2_logfile, '--wsrep_provider=' + self.wsrep_provider,
-                          self.sst_opts], env=os.environ)
+                          *self.sst_opts], env=os.environ)
         self.startup_check(self.node2_socket)
         os.system("cat " + self.node2_logfile)
         subprocess.Popen([self.mysqld, '--defaults-file=' + self.node3_cnf, '--basedir=' + self.basedir,
                           '--datadir=' + self.node3_datadir,
                           '--tmpdir=' + self.node3_datadir, '--socket=' + self.node3_socket,
                           '--log-error=' + self.node3_logfile, '--wsrep_provider=' + self.wsrep_provider,
-                          self.sst_opts], env=os.environ)
+                          *self.sst_opts], env=os.environ)
         self.startup_check(self.node3_socket)
         os.system("cat " + self.node3_logfile)
 

--- a/binary-tarball-tests/pxc/run.sh
+++ b/binary-tarball-tests/pxc/run.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 export PATH=${HOME}/.local/bin:${PATH}
 
+PXC_MAJOR_VERSION="$(echo ${PXC_VERSION}|cut -d'.' -f1,2)"
+
 echo "Installing dependencies..."
 if [ -f /etc/redhat-release ]; then
   sudo yum install -y libaio numactl openssl socat lsof
@@ -13,6 +15,10 @@ if [ -f /etc/redhat-release ]; then
   else
     sudo yum install -y python3 python3-pip
   fi
+  if [ "${PXC_MAJOR_VERSION}" = "5.7" ]; then
+    sudo yum install -y https://repo.percona.com/yum/percona-release-latest.noarch.rpm
+    sudo yum install -y percona-xtrabackup-24
+  fi
 else
   UCF_FORCE_CONFOLD=1 DEBIAN_FRONTEND=noninteractive sudo -E apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -qq -y install openssl
   if [[ $(lsb_release -sc) == 'xenial' ]]; then
@@ -24,7 +30,13 @@ else
   else
     sudo apt install -y python3 python3-pip
   fi
-  sudo apt install -y python3 python3-pip libaio1 libnuma1 socat lsof
+  sudo apt install -y python3 python3-pip libaio1 libnuma1 socat lsof curl
+  if [ "${PXC_MAJOR_VERSION}" = "5.7" ]; then
+    wget -q https://repo.percona.com/apt/percona-release_latest.$(lsb_release -sc)_all.deb
+    sudo dpkg -i percona-release_latest.$(lsb_release -sc)_all.deb
+    sudo apt update
+    sudo apt-get install -y percona-xtrabackup-24
+  fi
 fi
 pip3 install --user pytest-testinfra pytest
 

--- a/binary-tarball-tests/pxc/settings.py
+++ b/binary-tarball-tests/pxc/settings.py
@@ -12,8 +12,9 @@ pxc_version_major = pxc_version_percona.split('.')[0] + '.' + pxc_version_percon
 if pxc_version_major == "5.7":
   print(pxc_version)
   print(pxc57_pkg_version)
-  pxc57_client_version = pxc_version.split('-')[0] + '-' + pxc_version.split('-')[1]
-  pxc57_server_version = pxc57_pkg_version.split('-')[0] + '-rel' + pxc57_pkg_version.split('-')[1] + '-' + pxc57_pkg_version.split('-')[2]
+  pxc57_client_version = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1][3:]
+  pxc57_server_version_norel = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1][3:] + '-' + pxc57_pkg_version.split('-')[2].split('.')[0]
+  pxc57_server_version = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1] + '-' + pxc57_pkg_version.split('-')[2].split('.')[0]
 
 # 8.0
 pxc80_binaries = (

--- a/binary-tarball-tests/pxc/settings.py
+++ b/binary-tarball-tests/pxc/settings.py
@@ -89,12 +89,14 @@ pxc57_files = (
   'lib/mysql/plugin/keyring_file.so', 'lib/mysql/plugin/keyring_udf.so', 'lib/mysql/plugin/keyring_vault.so'
 )
 pxc57_symlinks = (
-  ('lib/libperconaserverclient.so','lib/libperconaserverclient.so.20.3.20'), ('lib/libncurses.so','lib/private/libncurses.so.5.9'),
-  ('lib/libcrypto.so','lib/private/libcrypto.so.1.0.1e'), ('lib/libssl.so','lib/private/libssl.so.1.0.1e'),
-  ('lib/libk5crypto.so','lib/private/libk5crypto.so.3.1'), ('lib/libtinfo.so','lib/private/libtinfo.so.5.7'),
-  ('lib/libsasl2.so','lib/private/libsasl2.so.2.0.23'), ('lib/libreadline.so','lib/private/libreadline.so.6.0'),
-  ('lib/libperconaserverclient.so.20','lib/libperconaserverclient.so.20.3.18'), ('lib/libkrb5support.so','lib/private/libkrb5support.so.0.1'),
-  ('lib/libkrb5.so','lib/private/libkrb5.so.3.3'), ('lib/libgssapi_krb5.so','lib/private/libgssapi_krb5.so.2.2')
+  ('lib/libperconaserverclient.so','lib/libperconaserverclient.so.20.3.20'),
+  ('lib/libperconaserverclient.so.20','lib/libperconaserverclient.so.20.3.20'),
+  ('lib/libncurses.so','lib/private/libncurses.so.5.9'),
+  ('lib/libcrypto.so','lib/private/libcrypto.so.1.0.2k'),
+  ('lib/libssl.so','lib/private/libssl.so.1.0.2k'),
+  ('lib/libtinfo.so','lib/private/libtinfo.so.5.9'),
+  ('lib/libsasl2.so','lib/private/libsasl2.so.3.0.0'),
+  ('lib/libreadline.so','lib/private/libreadline.so.6.2'),
 )
 
 # 5.6

--- a/binary-tarball-tests/pxc/settings.py
+++ b/binary-tarball-tests/pxc/settings.py
@@ -59,12 +59,15 @@ pxc80_symlinks = (
 
 # 5.7
 pxc57_binaries = (
-  'bin/clustercheck', 'bin/garbd', 'bin/wsrep_sst_common', 'bin/wsrep_sst_xtrabackup-v2',
-  'bin/wsrep_sst_mysqldump', 'bin/wsrep_sst_rsync', 'bin/pyclustercheck',
-  'bin/mysql', 'bin/mysqld', 'bin/ps-admin', 'bin/mysqladmin', 'bin/mysqlbinlog',
-  'bin/mysqldump', 'bin/mysqldumpslow', 'bin/mysqlimport', 'bin/mysqlpump', 'bin/mysqlshow',
-  'bin/mysqlslap', 'bin/mysqlcheck', 'bin/mysql_config_editor', 'bin/mysql_config', 'bin/mysql_ldb',
-  'bin/mysql_secure_installation', 'bin/mysql_ssl_rsa_setup', 'bin/mysql_upgrade', 'bin/mysql_tzinfo_to_sql'
+  'bin/clustercheck', 'bin/garbd', 'bin/innochecksum', 'bin/lz4_decompress', 'bin/my_print_defaults',
+  'bin/myisam_ftdump','bin/myisamchk', 'bin/myisamlog', 'bin/myisampack', 'bin/mysql', 'bin/mysql_client_test',
+  'bin/mysql_config', 'bin/mysql_config_editor', 'bin/mysql_install_db', 'bin/mysql_plugin', 'bin/mysql_secure_installation',
+  'bin/mysql_ssl_rsa_setup', 'bin/mysql_tzinfo_to_sql', 'bin/mysql_upgrade', 'bin/mysqladmin', 'bin/mysqlbinlog',
+  'bin/mysqlcheck', 'bin/mysqld', 'bin/mysqld_multi', 'bin/mysqld_safe', 'bin/mysqldump', 'bin/mysqldumpslow',
+  'bin/mysqlimport', 'bin/mysqlpump', 'bin/mysqlshow', 'bin/mysqlslap', 'bin/mysqltest', 'bin/mysqlxtest', 'bin/perror',
+  'bin/ps-admin', 'bin/ps_mysqld_helper', 'bin/ps_tokudb_admin', 'bin/pyclustercheck', 'bin/replace', 'bin/resolve_stack_dump',
+  'bin/resolveip', 'bin/wsrep_sst_common', 'bin/wsrep_sst_mysqldump', 'bin/wsrep_sst_rsync', 'bin/wsrep_sst_xtrabackup-v2',
+  'bin/zlib_decompress'
 )
 pxc57_plugins = (
   ('audit_log','audit_log.so'),('mysql_no_login','mysql_no_login.so'),('validate_password','validate_password.so'),

--- a/binary-tarball-tests/pxc/tests/test_pxc_dynamic.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_dynamic.py
@@ -11,7 +11,7 @@ def mysql_server(request):
     mysql_server = mysql.MySQL(base_dir)
     mysql_server.start()
     yield mysql_server
-    mysql_server.purge()
+    mysql_server.stop()
 
 def test_install_functions(mysql_server):
     for function in pxc_functions:

--- a/binary-tarball-tests/pxc/tests/test_pxc_dynamic.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_dynamic.py
@@ -21,3 +21,6 @@ def test_install_plugin(mysql_server):
     for plugin in pxc_plugins:
         mysql_server.install_plugin(plugin[0], plugin[1])
 
+def test_cluster_size(mysql_server):
+    output = mysql_server.run_query('"SHOW STATUS LIKE \\\"wsrep_cluster_size\\\";"')
+    assert output.split('\t')[1].strip() == "3"

--- a/binary-tarball-tests/pxc/tests/test_pxc_dynamic.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_dynamic.py
@@ -22,5 +22,5 @@ def test_install_plugin(mysql_server):
         mysql_server.install_plugin(plugin[0], plugin[1])
 
 def test_cluster_size(mysql_server):
-    output = mysql_server.run_query('"SHOW STATUS LIKE \\\"wsrep_cluster_size\\\";"')
+    output = mysql_server.run_query('SHOW STATUS LIKE "wsrep_cluster_size";')
     assert output.split('\t')[1].strip() == "3"

--- a/binary-tarball-tests/pxc/tests/test_pxc_static.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_static.py
@@ -44,3 +44,4 @@ def test_symlinks(host):
     for symlink in pxc_symlinks:
         assert host.file(base_dir+'/'+symlink[0]).is_symlink
         assert host.file(base_dir+'/'+symlink[0]).linked_to == base_dir+'/'+symlink[1]
+        assert host.file(base_dir+'/'+symlink[1]).exists

--- a/binary-tarball-tests/pxc/tests/test_pxc_static.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_static.py
@@ -9,13 +9,31 @@ def test_binaries_exist(host):
         assert host.file(base_dir+'/'+binary).exists
         assert oct(host.file(base_dir+'/'+binary).mode) == '0o755'
 
-def test_binaries_version(host):
+def test_mysql_version(host):
     if pxc_version_major in ['5.7','5.6']:
-        assert 'mysql  Ver 14.14 Distrib '+pxc57_client_version+', for Linux (x86_64) using  6.2' in host.check_output(base_dir+'/bin/mysql --version')
-        assert 'mysqld  Ver '+pxc57_server_version_norel+' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+pxc57_server_version+', Revision '+pxc_revision+', wsrep_'+wsrep_version+')' in host.check_output(base_dir+'/bin/mysqld --version')
+        expected = 'mysql  Ver 14.14 Distrib ' + pxc57_client_version + ', for Linux (x86_64) using  6.2'
+        assert expected in host.check_output(base_dir+'/bin/mysql --version')
     else:
-        assert 'mysql  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+ pxc_version_percona +', Revision '+ pxc_revision +', WSREP version '+wsrep_version+')' in host.check_output(base_dir+'/bin/mysql --version')
-        assert 'mysqld  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+ pxc_version_percona +', Revision '+ pxc_revision +', WSREP version '+wsrep_version+')' in host.check_output(base_dir+'/bin/mysqld --version')
+        expected = (
+            'mysql  Ver ' + pxc_version + ' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) ' +
+            pxc_version_percona + ', Revision ' + pxc_revision + ', WSREP version ' + wsrep_version + ')'
+        )
+        assert expected in host.check_output(base_dir+'/bin/mysql --version')
+
+def test_mysqld_version(host):
+    if pxc_version_major in ['5.7','5.6']:
+        expected = (
+            'mysqld  Ver ' + pxc57_server_version_norel + ' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) ' +
+            pxc57_server_version + ', Revision ' + pxc_revision + ', wsrep_' + wsrep_version + ')'
+        )
+        assert expected in host.check_output(base_dir+'/bin/mysqld --version')
+    else:
+        expected = (
+            'mysqld  Ver ' + pxc_version + ' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) ' +
+            pxc_version_percona + ', Revision ' + pxc_revision + ', WSREP version ' + wsrep_version + ')'
+        )
+        assert expected in host.check_output(base_dir+'/bin/mysqld --version')
+
 
 def test_files_exist(host):
     for f in pxc_files:

--- a/binary-tarball-tests/pxc/tests/test_pxc_static.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_static.py
@@ -11,8 +11,8 @@ def test_binaries_exist(host):
 
 def test_binaries_version(host):
     if pxc_version_major in ['5.7','5.6']:
-        assert 'mysql  Ver 14.14 Distrib '+pxc57_client_version+', for Linux (x86_64) using  6.0' in host.check_output(base_dir+'/bin/mysql --version')
-        assert 'mysqld  Ver '+pxc_version+' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+pxc57_server_version+', Revision '+pxc_revision+', wsrep_'+wsrep_version+')' in host.check_output(base_dir+'/bin/mysqld --version')
+        assert 'mysql  Ver 14.14 Distrib '+pxc57_client_version+', for Linux (x86_64) using  6.2' in host.check_output(base_dir+'/bin/mysql --version')
+        assert 'mysqld  Ver '+pxc57_server_version_norel+' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+pxc57_server_version+', Revision '+pxc_revision+', wsrep_'+wsrep_version+')' in host.check_output(base_dir+'/bin/mysqld --version')
     else:
         assert 'mysql  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+ pxc_version_percona +', Revision '+ pxc_revision +', WSREP version '+wsrep_version+')' in host.check_output(base_dir+'/bin/mysql --version')
         assert 'mysqld  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster binary (GPL) '+ pxc_version_percona +', Revision '+ pxc_revision +', WSREP version '+wsrep_version+')' in host.check_output(base_dir+'/bin/mysqld --version')


### PR DESCRIPTION
This PR fixes the binary tarball tests for PXC 5.7 and adds a few quality-of-life improvements. Tested locally with Centos 8 and Debian Stretch. Main changes are as follows:

- Updated list of expected files and symlinks for testing version 5.7.
- Fixed cluster SST connection in version 5.7.
- Added installation of XtraBackup 2.4 to the run script when testing version 5.7.
- Removed some unused functions or unneeded features from the PXC binary tarball tests, such as a sleep statement after shutdown or logs cleanup.
- Implemented automatic shell escaping and quoting to SQL query runs, in both PXC and PS binary tarball tests.
- Added new test on cluster size.
- Changed existing tests on plugin/function installation so that the installation is asserted against non-primary nodes.
- Added more assertions on symlink test.