### PR TITLE
Add Centos6 support for PXC 5.7 tarball tests

### DIFF
--- a/binary-tarball-tests/pxc/Vagrantfile
+++ b/binary-tarball-tests/pxc/Vagrantfile
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/centos8"
+  config.vm.box = "generic/centos6"
   
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     ### 5.7
@@ -27,7 +27,11 @@ Vagrant.configure("2") do |config|
       TARBALL_NAME="Percona-XtraDB-Cluster_${PXC_VERSION}_Linux.x86_64.glibc2.17${MINIMAL}.tar.gz"
       TARBALL_LINK="https://downloads.percona.com/downloads/TESTING/pxc-${PXC_VERSION}/"
     elif [ "${PXC_MAJOR_VERSION}" = "5.7" ]; then
-      TARBALL_NAME="Percona-XtraDB-Cluster-${PXC57_PKG_VERSION}.Linux.x86_64.glibc2.17${MINIMAL}.tar.gz"
+      export GLIBC_VERSION="2.17"
+      if [ -f /etc/redhat-release ] && [ $(grep -c "release 6" /etc/redhat-release) -eq 1 ]; then
+        export GLIBC_VERSION="2.12"
+      fi
+      TARBALL_NAME="Percona-XtraDB-Cluster-${PXC57_PKG_VERSION}.Linux.x86_64.glibc${GLIBC_VERSION}${MINIMAL}.tar.gz"
       TARBALL_LINK="https://downloads.percona.com/downloads/TESTING/pxc-${PXC_VERSION}/"
     fi
     rm -rf package-testing
@@ -36,7 +40,7 @@ Vagrant.configure("2") do |config|
     else
       sudo apt install -y git wget
     fi
-    git clone https://github.com/Percona-QA/package-testing.git --branch fix-pxc-57-binary-tarball --depth 1
+    git clone https://github.com/Percona-QA/package-testing.git --branch fix-pxc-57-centos-6 --depth 1
     cd package-testing/binary-tarball-tests/pxc
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true

--- a/binary-tarball-tests/pxc/run.sh
+++ b/binary-tarball-tests/pxc/run.sh
@@ -9,7 +9,8 @@ if [ -f /etc/redhat-release ]; then
   # below needed for 5.6 mysql_install_db
   sudo yum install -y perl-Data-Dumper
   if [ $(grep -c "release 6" /etc/redhat-release) -eq 1 ]; then
-    sudo yum install -y epel-release centos-release-scl
+    sudo yum install -y epel-release centos-release-scl libev
+    sudo sed -i -e 's/^mirrorlist/#mirrorlist/g' -e 's/^# *baseurl=http:\/\/mirror.centos.org\//baseurl=http:\/\/vault.centos.org\//g' /etc/yum.repos.d/CentOS-SCLo-scl*
     sudo yum install -y rh-python36 rh-python36-python-pip
     source /opt/rh/rh-python36/enable
   else

--- a/binary-tarball-tests/pxc/settings.py
+++ b/binary-tarball-tests/pxc/settings.py
@@ -6,6 +6,7 @@ pxc_version = os.getenv('PXC_VERSION')
 pxc_revision = os.getenv('PXC_REVISION')
 pxc57_pkg_version = os.getenv('PXC57_PKG_VERSION')
 wsrep_version = os.getenv('WSREP_VERSION')
+glibc_version = os.getenv('GLIBC_VERSION')
 
 pxc_version_percona = pxc_version.split('-')[0]
 pxc_version_major = pxc_version_percona.split('.')[0] + '.' + pxc_version_percona.split('.')[1]
@@ -15,6 +16,7 @@ if pxc_version_major == "5.7":
   pxc57_client_version = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1][3:]
   pxc57_server_version_norel = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1][3:] + '-' + pxc57_pkg_version.split('-')[2].split('.')[0]
   pxc57_server_version = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1] + '-' + pxc57_pkg_version.split('-')[2].split('.')[0]
+  pxc57_client_version_using = "6.0" if glibc_version == "2.12" else "6.2"
 
 # 8.0
 pxc80_binaries = (
@@ -88,16 +90,28 @@ pxc57_files = (
   'lib/mysql/plugin/auth_pam.so', 'lib/mysql/plugin/auth_pam_compat.so',
   'lib/mysql/plugin/keyring_file.so', 'lib/mysql/plugin/keyring_udf.so', 'lib/mysql/plugin/keyring_vault.so'
 )
-pxc57_symlinks = (
-  ('lib/libperconaserverclient.so','lib/libperconaserverclient.so.20.3.20'),
-  ('lib/libperconaserverclient.so.20','lib/libperconaserverclient.so.20.3.20'),
-  ('lib/libncurses.so','lib/private/libncurses.so.5.9'),
-  ('lib/libcrypto.so','lib/private/libcrypto.so.1.0.2k'),
-  ('lib/libssl.so','lib/private/libssl.so.1.0.2k'),
-  ('lib/libtinfo.so','lib/private/libtinfo.so.5.9'),
-  ('lib/libsasl2.so','lib/private/libsasl2.so.3.0.0'),
-  ('lib/libreadline.so','lib/private/libreadline.so.6.2'),
-)
+
+if glibc_version == "2.12":
+  pxc57_symlinks = (
+    ('lib/libperconaserverclient.so','lib/libperconaserverclient.so.20.3.20'),
+    ('lib/libperconaserverclient.so.20','lib/libperconaserverclient.so.20.3.20'),
+    ('lib/libcrypto.so','lib/private/libcrypto.so.1.0.1e'),
+    ('lib/libssl.so','lib/private/libssl.so.1.0.1e'),
+    ('lib/libtinfo.so','lib/private/libtinfo.so.5.7'),
+    ('lib/libsasl2.so','lib/private/libsasl2.so.2.0.23'),
+    ('lib/libreadline.so','lib/private/libreadline.so.6.0'),
+  )
+else:
+  pxc57_symlinks = (
+    ('lib/libperconaserverclient.so','lib/libperconaserverclient.so.20.3.20'),
+    ('lib/libperconaserverclient.so.20','lib/libperconaserverclient.so.20.3.20'),
+    ('lib/libncurses.so','lib/private/libncurses.so.5.9'),
+    ('lib/libcrypto.so','lib/private/libcrypto.so.1.0.2k'),
+    ('lib/libssl.so','lib/private/libssl.so.1.0.2k'),
+    ('lib/libtinfo.so','lib/private/libtinfo.so.5.9'),
+    ('lib/libsasl2.so','lib/private/libsasl2.so.3.0.0'),
+    ('lib/libreadline.so','lib/private/libreadline.so.6.2'),
+  )
 
 # 5.6
 pxc56_binaries = (

--- a/binary-tarball-tests/pxc/test-pxc-binary-tarball.groovy
+++ b/binary-tarball-tests/pxc/test-pxc-binary-tarball.groovy
@@ -71,6 +71,22 @@ pipeline {
             junit 'package-testing/binary-tarball-tests/pxc/report.xml'
           } //End steps
         } //End stage Debian Buster
+        stage('Centos6') {
+          when {
+            expression {
+              params.PXC_VERSION[0..2] == "5.7"
+            }
+          }
+          agent {
+            label "min-centos-6-x64"
+          }
+          steps {
+            withCredentials([usernamePassword(credentialsId: 'JenkinsAPI', passwordVariable: 'JENKINS_API_PWD', usernameVariable: 'JENKINS_API_USER')]) {
+              run_test()
+            }
+            junit 'package-testing/binary-tarball-tests/pxc/report.xml'
+          } //End steps
+        } //End stage CentOS6
         stage('Centos7') {
           agent {
             label "min-centos-7-x64"
@@ -110,7 +126,11 @@ void run_test() {
       TARBALL_NAME="Percona-XtraDB-Cluster_${PXC_VERSION}_Linux.x86_64.glibc2.17${MINIMAL}.tar.gz"
       TARBALL_LINK="https://downloads.percona.com/downloads/TESTING/pxc-${PXC_VERSION}/"
     elif [ "${PXC_MAJOR_VERSION}" = "5.7" ]; then
-      TARBALL_NAME="Percona-XtraDB-Cluster-${PXC57_PKG_VERSION}.Linux.x86_64.glibc2.17${MINIMAL}.tar.gz"
+      export GLIBC_VERSION="2.17"
+      if [ -f /etc/redhat-release ] && [ $(grep -c "release 6" /etc/redhat-release) -eq 1 ]; then
+        export GLIBC_VERSION="2.12"
+      fi
+      TARBALL_NAME="Percona-XtraDB-Cluster-${PXC57_PKG_VERSION}.Linux.x86_64.glibc${GLIBC_VERSION}${MINIMAL}.tar.gz"
       TARBALL_LINK="https://downloads.percona.com/downloads/TESTING/pxc-${PXC_VERSION}/"
     fi
     rm -rf package-testing

--- a/binary-tarball-tests/pxc/tests/test_pxc_static.py
+++ b/binary-tarball-tests/pxc/tests/test_pxc_static.py
@@ -11,7 +11,10 @@ def test_binaries_exist(host):
 
 def test_mysql_version(host):
     if pxc_version_major in ['5.7','5.6']:
-        expected = 'mysql  Ver 14.14 Distrib ' + pxc57_client_version + ', for Linux (x86_64) using  6.2'
+        expected = (
+            'mysql  Ver 14.14 Distrib ' + pxc57_client_version + ', for Linux (x86_64) using  ' +
+            pxc57_client_version_using
+        )
         assert expected in host.check_output(base_dir+'/bin/mysql --version')
     else:
         expected = (


### PR DESCRIPTION
This PR adds support for Centos 6 in the PXC 5.7 tarball tests. Changes are as follows:

- Tarball download script now downloads the `glibc2.12` variant of the tarball instead of the `glibc2.17` one when running on Centos 6. It also exports the version number used as the `GLIBC_VERSION` environment variable.
- MySQL version string test expects a different version string for Centos 6, since the version string includes the `libreadline` version, which varies between tarballs.
- For that same reason, the lib symlinks tests also expect different libraries (`libncurses` is absent) and different versions of those libraries.
- The installation script installs `libev`, which is required by XtraBackup when on Centos 6, and performs some unholy `sed` magic to "fix" the SCL yum repositories by pointing them to the Centos vault server.
- The corresponding Jenkins pipeline job runs tests on Centos 6 when the PXC version number to test is 5.7.