### PR TITLE
Test linked libraries in PS binary tarball

### DIFF
--- a/binary-tarball-tests/ps/Vagrantfile
+++ b/binary-tarball-tests/ps/Vagrantfile
@@ -1,0 +1,39 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "generic/centos8"
+  
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    export PS_VERSION=8.0.23-14
+    export PS_REVISION=3558242
+
+    echo ${BUILD_TYPE_MINIMAL}
+    PS_MAJOR_VERSION="$(echo ${PS_VERSION}|cut -d'.' -f1,2)"
+    MINIMAL=""
+    if [ "${BUILD_TYPE_MINIMAL}" = "true" ]; then
+      MINIMAL="-minimal"
+    fi
+    if [ "${PS_MAJOR_VERSION}" = "8.0" ]; then
+      export GLIBC_VERSION="2.17"
+      if [ -f /etc/redhat-release ] && [ $(grep -c "release 6" /etc/redhat-release) -eq 1 ]; then
+        export GLIBC_VERSION="2.12"
+      fi
+      TARBALL_NAME="Percona-Server-${PS_VERSION}-Linux.x86_64.glibc${GLIBC_VERSION}${MINIMAL}.tar.gz"
+      TARBALL_LINK="https://www.percona.com/downloads/TESTING/ps-${PS_VERSION}/"
+    elif [ "${PS_MAJOR_VERSION}" = "5.7" ]; then
+      TARBALL_NAME="Percona-Server-${PS_VERSION}-Linux.x86_64.glibc2.12${MINIMAL}.tar.gz"
+      TARBALL_LINK="https://www.percona.com/downloads/TESTING/ps-${PS_VERSION}/"
+    fi
+    rm -rf package-testing
+    if [ -f /usr/bin/yum ]; then
+      sudo yum install -y git wget
+    else
+      sudo apt install -y git wget lsb-release
+    fi
+    git clone https://github.com/Percona-QA/package-testing.git --branch ps-tarball-test-linked-libraries --depth 1
+    cd package-testing/binary-tarball-tests/ps
+    wget -q ${TARBALL_LINK}${TARBALL_NAME}
+    ./run.sh || true
+  SHELL
+end

--- a/binary-tarball-tests/ps/settings.py
+++ b/binary-tarball-tests/ps/settings.py
@@ -9,13 +9,18 @@ ps_version_upstream, ps_version_percona = ps_version.split('-')
 ps_version_major = ps_version_upstream.split('.')[0] + '.' + ps_version_upstream.split('.')[1]
 
 # 8.0
-ps80_binaries = (
-  'bin/mysql', 'bin/mysqld', 'bin/ps-admin', 'bin/mysqladmin', 'bin/mysqlbinlog',
-  'bin/mysqldump', 'bin/mysqldumpslow', 'bin/mysqlimport', 'bin/mysqlpump', 'bin/mysqlshow',
-  'bin/mysqlslap', 'bin/mysqlcheck', 'bin/mysql_config_editor', 'bin/mysql_config', 'bin/mysql_ldb',
+ps80_binaries = [
+  'bin/mysql', 'bin/mysqld', 'bin/mysqladmin', 'bin/mysqlbinlog',
+  'bin/mysqldump', 'bin/mysqlimport', 'bin/mysqlpump', 'bin/mysqlshow',
+  'bin/mysqlslap', 'bin/mysqlcheck', 'bin/mysql_config_editor', 'bin/mysql_ldb',
   'bin/mysqlrouter', 'bin/mysqlrouter_passwd', 'bin/mysqlrouter_plugin_info', 'bin/mysql_secure_installation', 'bin/mysql_ssl_rsa_setup',
   'bin/mysql_upgrade', 'bin/mysql_tzinfo_to_sql'
-)
+]
+ps80_executables = ps80_binaries + [
+  'bin/ps-admin',
+  'bin/mysqldumpslow',
+  'bin/mysql_config',
+]
 ps80_plugins = (
   ('audit_log','audit_log.so'),('mysql_no_login','mysql_no_login.so'),('validate_password','validate_password.so'),
   ('version_tokens','version_token.so'),('rpl_semi_sync_master','semisync_master.so'),('rpl_semi_sync_slave','semisync_slave.so'),
@@ -46,12 +51,17 @@ ps80_symlinks = (
 )
 
 # 5.7
-ps57_binaries = (
-  'bin/mysql', 'bin/mysqld', 'bin/ps-admin', 'bin/mysqladmin', 'bin/mysqlbinlog',
-  'bin/mysqldump', 'bin/mysqldumpslow', 'bin/mysqlimport', 'bin/mysqlpump', 'bin/mysqlshow',
-  'bin/mysqlslap', 'bin/mysqlcheck', 'bin/mysql_config_editor', 'bin/mysql_config', 'bin/mysql_ldb',
+ps57_binaries = [
+  'bin/mysql', 'bin/mysqld', 'bin/mysqladmin', 'bin/mysqlbinlog',
+  'bin/mysqldump', 'bin/mysqlimport', 'bin/mysqlpump', 'bin/mysqlshow',
+  'bin/mysqlslap', 'bin/mysqlcheck', 'bin/mysql_config_editor', 'bin/mysql_ldb',
   'bin/mysql_secure_installation', 'bin/mysql_ssl_rsa_setup', 'bin/mysql_upgrade', 'bin/mysql_tzinfo_to_sql'
-)
+]
+ps57_executables = ps57_binaries + [
+  'bin/ps-admin',
+  'bin/mysqldumpslow',
+  'bin/mysql_config',
+]
 ps57_plugins = (
   ('audit_log','audit_log.so'),('mysql_no_login','mysql_no_login.so'),('validate_password','validate_password.so'),
   ('version_tokens','version_token.so'),('rpl_semi_sync_master','semisync_master.so'),('rpl_semi_sync_slave','semisync_slave.so'),
@@ -77,10 +87,14 @@ ps57_symlinks = (
 )
 
 # 5.6
-ps56_binaries = (
+ps56_binaries = [
   'bin/mysql', 'bin/mysqld', 'bin/mysqladmin', 'bin/mysqlbinlog', 'bin/mysqldump',
-  'bin/mysqldumpslow', 'bin/mysqlimport', 'bin/mysqlshow', 'bin/mysqlslap', 'bin/mysqlcheck',
-  'bin/mysql_config_editor', 'bin/mysql_secure_installation', 'bin/mysql_upgrade', 'bin/mysql_tzinfo_to_sql')
+  'bin/mysqlimport', 'bin/mysqlshow', 'bin/mysqlslap', 'bin/mysqlcheck',
+  'bin/mysql_config_editor', 'bin/mysql_secure_installation', 'bin/mysql_upgrade', 'bin/mysql_tzinfo_to_sql'
+]
+ps56_executables = ps56_binaries + [
+  'bin/mysqldumpslow',
+]
 ps56_plugins = (
   ('audit_log','audit_log.so'),('mysql_no_login','mysql_no_login.so'),('validate_password','validate_password.so'),
   ('rpl_semi_sync_master','semisync_master.so'),('rpl_semi_sync_slave','semisync_slave.so')
@@ -103,18 +117,21 @@ ps56_symlinks = (
 
 if ps_version_major == '8.0':
     ps_binaries = ps80_binaries
+    ps_executables = ps80_executables
     ps_plugins = ps80_plugins
     ps_functions = ps80_functions
     ps_files = ps80_files
     ps_symlinks = ps80_symlinks
 elif ps_version_major == '5.7':
     ps_binaries = ps57_binaries
+    ps_executables = ps57_executables
     ps_plugins = ps57_plugins
     ps_functions = ps57_functions
     ps_files = ps57_files
     ps_symlinks = ps57_symlinks
 elif ps_version_major == '5.6':
     ps_binaries = ps56_binaries
+    ps_executables = ps56_executables
     ps_plugins = ps56_plugins
     ps_functions = ps56_functions
     ps_files = ps56_files

--- a/binary-tarball-tests/ps/tests/test_ps_static.py
+++ b/binary-tarball-tests/ps/tests/test_ps_static.py
@@ -26,3 +26,4 @@ def test_symlinks(host):
     for symlink in ps_symlinks:
         assert host.file(base_dir+'/'+symlink[0]).is_symlink
         assert host.file(base_dir+'/'+symlink[0]).linked_to == base_dir+'/'+symlink[1]
+        assert host.file(base_dir+'/'+symlink[1]).exists

--- a/binary-tarball-tests/ps/tests/test_ps_static.py
+++ b/binary-tarball-tests/ps/tests/test_ps_static.py
@@ -4,10 +4,10 @@ import testinfra
 
 from settings import *
 
-def test_binaries_exist(host):
-    for binary in ps_binaries:
-        assert host.file(base_dir+'/'+binary).exists
-        assert oct(host.file(base_dir+'/'+binary).mode) == '0o755'
+def test_executables_exist(host):
+    for executable in ps_executables:
+        assert host.file(base_dir+'/'+executable).exists
+        assert oct(host.file(base_dir+'/'+executable).mode) == '0o755'
 
 def test_binaries_version(host):
     if ps_version_major in ['5.7','5.6']:
@@ -27,3 +27,7 @@ def test_symlinks(host):
         assert host.file(base_dir+'/'+symlink[0]).is_symlink
         assert host.file(base_dir+'/'+symlink[0]).linked_to == base_dir+'/'+symlink[1]
         assert host.file(base_dir+'/'+symlink[1]).exists
+
+def test_binaries_linked_libraries(host):
+    for binary in ps_binaries:
+        assert '=> not found' not in host.check_output('ldd ' + base_dir + '/' + binary)


### PR DESCRIPTION
Porting some of the changes made to the PXC binary tarball tests in #79 and #81 over to the PS tests, specifically:

- Added a Vagrantfile with the contents of the Jenkins job to make local testing easier
- Implemented the linked libraries test as in PXC (see #81)
- Added a check to the symlink test to ensure the symlink destination exists