### PR TITLE
Fix PXC 5.7 Docker image tests

### DIFF
--- a/docker-image-tests/pxc/Jenkinsfile
+++ b/docker-image-tests/pxc/Jenkinsfile
@@ -9,6 +9,8 @@ pipeline {
     string(name: 'PXC_VERSION', defaultValue: '8.0.22-13.1', description: 'Full PXC version')
     string(name: 'PXC_REVISION', defaultValue: '428f061', description: 'Short git hash for release')
     string(name: 'PXC_WSREP_VERSION', defaultValue: '26.4.3', description: 'Galera WSREP version')
+    string(name: 'PXC_PXB_VERSION', defaultValue: '2.4.22', description: 'PXB version installed (only for PXC 5.7)')
+    string(name: 'PXC57_PKG_VERSION', defaultValue: '5.7.33-rel36-49.1', description: 'PXC package version (only for PXC 5.7)')
   }
   stages {
     stage('Run test') {

--- a/docker-image-tests/pxc/settings.py
+++ b/docker-image-tests/pxc/settings.py
@@ -6,6 +6,7 @@ docker_product = os.getenv('DOCKER_PRODUCT')
 docker_tag = os.getenv('DOCKER_TAG')
 pxc_version = os.getenv('PXC_VERSION')
 pxc_revision = os.getenv('PXC_REVISION')
+pxc_pxb_version = os.getenv('PXC_PXB_VERSION')
 pxc_wsrep_version = os.getenv('PXC_WSREP_VERSION')
 test_pwd = os.path.dirname(os.path.realpath(__file__))
 
@@ -20,10 +21,10 @@ base_node_name = 'pxc-docker-test-cluster-node'
 cluster_name = 'pxc-cluster1'
 
 # 8.0
-pxc80_packages = (
+pxc80_packages = [(package, pxc_version_upstream) for package in (
   'percona-xtradb-cluster-client', 'percona-xtradb-cluster-server',
   'percona-xtradb-cluster-shared', 'percona-xtradb-cluster-shared-compat'
-)
+)]
 pxc80_binaries = (
   '/usr/bin/mysql', '/usr/sbin/mysqld', '/usr/bin/mysqladmin',
   '/usr/bin/mysqldump', '/usr/bin/mysqldumpslow',
@@ -49,8 +50,10 @@ pxc80_functions = (
 
 # 5.7
 pxc57_packages = (
-  'Percona-XtraDB-Cluster-shared-57', 'Percona-XtraDB-Cluster-server-57',
-  'Percona-XtraDB-Cluster-client-57', 'percona-xtrabackup-24'
+  ('Percona-XtraDB-Cluster-shared-57', pxc_version_upstream),
+  ('Percona-XtraDB-Cluster-server-57', pxc_version_upstream),
+  ('Percona-XtraDB-Cluster-client-57', pxc_version_upstream),
+  ('percona-xtrabackup-24', pxc_pxb_version)
 )
 pxc57_binaries = (
   '/usr/bin/mysql', '/usr/sbin/mysqld',
@@ -71,10 +74,10 @@ pxc57_functions = (
 )
 
 # 5.6
-pxc56_packages = (
+pxc56_packages = [(package, pxc_version_upstream) for package in (
   'Percona-Server-client-56', 'Percona-Server-server-56', 'Percona-Server-shared-56',
   'Percona-Server-tokudb-56'
-)
+)]
 pxc56_binaries = (
   '/usr/bin/mysql', '/usr/sbin/mysqld', '/usr/bin/mysqladmin', '/usr/bin/mysqlbinlog', '/usr/sbin/mysqld-debug',
   '/usr/bin/mysqldump', '/usr/bin/mysqldumpslow', '/usr/bin/mysqlimport', '/usr/bin/mysqlshow', '/usr/bin/mysqlslap',

--- a/docker-image-tests/pxc/settings.py
+++ b/docker-image-tests/pxc/settings.py
@@ -49,8 +49,8 @@ pxc80_functions = (
 
 # 5.7
 pxc57_packages = (
-  'Percona-Server-shared-compat-57', 'Percona-XtraDB-Cluster-shared-57', 'Percona-XtraDB-Cluster-server-57',
-  'Percona-Server-shared-57', 'Percona-XtraDB-Cluster-client-57', 'percona-xtrabackup-24'
+  'Percona-XtraDB-Cluster-shared-57', 'Percona-XtraDB-Cluster-server-57',
+  'Percona-XtraDB-Cluster-client-57', 'percona-xtrabackup-24'
 )
 pxc57_binaries = (
   '/usr/bin/mysql', '/usr/sbin/mysqld',

--- a/docker-image-tests/pxc/settings.py
+++ b/docker-image-tests/pxc/settings.py
@@ -6,6 +6,7 @@ docker_product = os.getenv('DOCKER_PRODUCT')
 docker_tag = os.getenv('DOCKER_TAG')
 pxc_version = os.getenv('PXC_VERSION')
 pxc_revision = os.getenv('PXC_REVISION')
+pxc57_pkg_version = os.getenv('PXC57_PKG_VERSION')
 pxc_pxb_version = os.getenv('PXC_PXB_VERSION')
 pxc_wsrep_version = os.getenv('PXC_WSREP_VERSION')
 test_pwd = os.path.dirname(os.path.realpath(__file__))
@@ -13,6 +14,10 @@ test_pwd = os.path.dirname(os.path.realpath(__file__))
 pxc_version_upstream, pxc_version_percona = pxc_version.split('-')
 pxc_version_major = pxc_version_upstream.split('.')[0] + '.' + pxc_version_upstream.split('.')[1]
 pxc_rel=pxc_version_percona.split('.')[0]
+
+pxc57_client_version = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1][3:]
+pxc57_server_release = pxc57_pkg_version.split('-')[1]
+pxc57_server_version_norel = pxc57_pkg_version.split('-')[0] + '-' + pxc57_pkg_version.split('-')[1][3:] + '-' + pxc_version_major.replace('.', '')
 
 docker_image = docker_acc + "/" + docker_product + ":" + docker_tag
 docker_network = 'pxc-network'

--- a/docker-image-tests/pxc/settings.py
+++ b/docker-image-tests/pxc/settings.py
@@ -53,10 +53,9 @@ pxc57_packages = (
   'Percona-Server-shared-57', 'Percona-XtraDB-Cluster-client-57', 'percona-xtrabackup-24'
 )
 pxc57_binaries = (
-  '/usr/bin/mysql', '/usr/sbin/mysqld', '/usr/bin/ps-admin', '/usr/bin/mysqladmin', '/usr/bin/mysqlbinlog',
-  '/usr/sbin/mysqld-debug', '/usr/bin/mysqldump', '/usr/bin/mysqldumpslow', '/usr/bin/mysqlimport', '/usr/bin/mysqlpump',
-  '/usr/bin/mysqlshow', '/usr/bin/mysqlslap', '/usr/bin/mysqlcheck', '/usr/bin/mysql_config_editor', '/usr/bin/mysql_config',
-  '/usr/bin/mysql_config-64', '/usr/bin/mysql_ldb', '/usr/bin/mysql_secure_installation', '/usr/bin/mysql_ssl_rsa_setup', '/usr/bin/mysql_upgrade',
+  '/usr/bin/mysql', '/usr/sbin/mysqld',
+  '/usr/bin/mysqldump', '/usr/bin/mysqldumpslow',
+  '/usr/bin/mysql_secure_installation', '/usr/bin/mysql_ssl_rsa_setup', '/usr/bin/mysql_upgrade',
   '/usr/bin/mysql_tzinfo_to_sql'
 )
 pxc57_plugins = (

--- a/docker-image-tests/pxc/tests/test_pxc_cluster.py
+++ b/docker-image-tests/pxc/tests/test_pxc_cluster.py
@@ -14,7 +14,7 @@ class PxcNode:
             self.docker_id = subprocess.check_output(
                 ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd, 
                  '-e', 'CLUSTER_NAME='+cluster_name, '--net='+docker_network,'-d', docker_image]).decode().strip()
-            time.sleep(120)
+            time.sleep(20)
             if pxc_version_major == "8.0":
                 subprocess.check_call(['mkdir', '-p', test_pwd+'/cert'])
                 subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/ca.pem', test_pwd+'/cert'])
@@ -35,7 +35,6 @@ class PxcNode:
                 ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd,
                 '-e', 'CLUSTER_NAME='+cluster_name, '-e', 'CLUSTER_JOIN='+base_node_name+'1',
                 '--net='+docker_network, '-d', docker_image]).decode().strip()
-            time.sleep(120)
         self.ti_host = testinfra.get_host("docker://root@" + self.docker_id)
 
     def destroy(self):
@@ -47,6 +46,7 @@ class PxcNode:
 @pytest.fixture(scope='module')
 def cluster():
     cluster = []
+    subprocess.check_call(['docker', 'pull', docker_image])
     subprocess.check_call(['docker', 'network', 'create', docker_network])
     node1 = PxcNode(base_node_name+'1',True)
     cluster.append(node1)
@@ -54,6 +54,7 @@ def cluster():
     cluster.append(node2)
     node3 = PxcNode(base_node_name+'3',False)
     cluster.append(node3)
+    time.sleep(40)
     yield cluster
     for node in cluster:
         node.destroy()

--- a/docker-image-tests/pxc/tests/test_pxc_cluster.py
+++ b/docker-image-tests/pxc/tests/test_pxc_cluster.py
@@ -15,19 +15,26 @@ class PxcNode:
                 ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd, 
                  '-e', 'CLUSTER_NAME='+cluster_name, '--net='+docker_network,'-d', docker_image]).decode().strip()
             time.sleep(120)
-            subprocess.check_call(['mkdir', '-p', test_pwd+'/cert'])
-            subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/ca.pem', test_pwd+'/cert'])
-            subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/server-cert.pem', test_pwd+'/cert'])
-            subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/server-key.pem', test_pwd+'/cert'])
-            subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/client-cert.pem', test_pwd+'/cert'])
-            subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/client-key.pem', test_pwd+'/cert'])
-            subprocess.check_call(['chmod','-R','a+r', test_pwd+'/cert'])
+            if pxc_version_major == "8.0":
+                subprocess.check_call(['mkdir', '-p', test_pwd+'/cert'])
+                subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/ca.pem', test_pwd+'/cert'])
+                subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/server-cert.pem', test_pwd+'/cert'])
+                subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/server-key.pem', test_pwd+'/cert'])
+                subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/client-cert.pem', test_pwd+'/cert'])
+                subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/client-key.pem', test_pwd+'/cert'])
+                subprocess.check_call(['chmod','-R','a+r', test_pwd+'/cert'])
         else:
-            self.docker_id = subprocess.check_output(
-            ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd, 
-             '-e', 'CLUSTER_NAME='+cluster_name, '-e', 'CLUSTER_JOIN='+base_node_name+'1', 
-             '--net='+docker_network,'-v', test_pwd+'/config:/etc/percona-xtradb-cluster.conf.d', 
-             '-v', test_pwd+'/cert:/cert', '-d', docker_image]).decode().strip()
+            if pxc_version_major == "8.0":
+                self.docker_id = subprocess.check_output(
+                ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd,
+                '-e', 'CLUSTER_NAME='+cluster_name, '-e', 'CLUSTER_JOIN='+base_node_name+'1',
+                '--net='+docker_network,'-v', test_pwd+'/config:/etc/percona-xtradb-cluster.conf.d',
+                '-v', test_pwd+'/cert:/cert', '-d', docker_image]).decode().strip()
+            else:
+                self.docker_id = subprocess.check_output(
+                ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd,
+                '-e', 'CLUSTER_NAME='+cluster_name, '-e', 'CLUSTER_JOIN='+base_node_name+'1',
+                '--net='+docker_network, '-d', docker_image]).decode().strip()
             time.sleep(120)
         self.ti_host = testinfra.get_host("docker://root@" + self.docker_id)
 

--- a/docker-image-tests/pxc/tests/test_pxc_cluster.py
+++ b/docker-image-tests/pxc/tests/test_pxc_cluster.py
@@ -94,3 +94,8 @@ class TestCluster:
             cmd = node.ti_host.run('mysql --user=root --password='+pxc_pwd+' -S/tmp/mysql.sock -s -N -e "select count(*) from test.t1;"')
             assert cmd.succeeded
             assert '4' in cmd.stdout
+
+    def test_cluster_size(self, cluster):
+        cmd = cluster[0].ti_host.run('mysql --user=root --password='+pxc_pwd+' -S/tmp/mysql.sock -s -N -e "SHOW STATUS LIKE \'wsrep_cluster_size\';"')
+        assert cmd.succeeded
+        assert cmd.stdout.split('\t')[1].strip() == "3"

--- a/docker-image-tests/pxc/tests/test_pxc_cluster.py
+++ b/docker-image-tests/pxc/tests/test_pxc_cluster.py
@@ -21,7 +21,7 @@ class PxcNode:
             subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/server-key.pem', test_pwd+'/cert'])
             subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/client-cert.pem', test_pwd+'/cert'])
             subprocess.check_call(['docker', 'cp', node_name+':/var/lib/mysql/client-key.pem', test_pwd+'/cert'])
-            subprocess.check_call(['chmod','a+r','-R', test_pwd+'/cert'])
+            subprocess.check_call(['chmod','-R','a+r', test_pwd+'/cert'])
         else:
             self.docker_id = subprocess.check_output(
             ['docker', 'run', '--name', node_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd, 

--- a/docker-image-tests/pxc/tests/test_pxc_static.py
+++ b/docker-image-tests/pxc/tests/test_pxc_static.py
@@ -33,12 +33,16 @@ class TestMysqlEnvironment:
         assert host.file(binary).exists
         assert oct(host.file(binary).mode) == '0o755'
 
-    def test_binaries_version(self, host):
+    def test_mysql_version(self, host):
         if pxc_version_major in ['5.7','5.6']:
             assert host.check_output('mysql --version') == 'mysql  Ver 14.14 Distrib '+pxc_version+', for Linux (x86_64) using  6.2'
-            assert host.check_output('mysqld --version') == 'mysqld  Ver '+pxc_version+' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+pxc_version_percona+', Revision '+pxc_revision+')'
         else:
             assert host.check_output('mysql --version') == 'mysql  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+ pxc_rel +', Revision '+ pxc_revision +', WSREP version '+ pxc_wsrep_version +')'
+
+    def test_mysqld_version(self, host):
+        if pxc_version_major in ['5.7','5.6']:
+            assert host.check_output('mysqld --version') == 'mysqld  Ver '+pxc_version+' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+pxc_version_percona+', Revision '+pxc_revision+')'
+        else:
             assert host.check_output('mysqld --version') == '/usr/sbin/mysqld  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+ pxc_rel +', Revision '+ pxc_revision +', WSREP version '+ pxc_wsrep_version +')'
 
     def test_process_running(self, host):

--- a/docker-image-tests/pxc/tests/test_pxc_static.py
+++ b/docker-image-tests/pxc/tests/test_pxc_static.py
@@ -35,13 +35,13 @@ class TestMysqlEnvironment:
 
     def test_mysql_version(self, host):
         if pxc_version_major in ['5.7','5.6']:
-            assert host.check_output('mysql --version') == 'mysql  Ver 14.14 Distrib '+pxc_version+', for Linux (x86_64) using  6.2'
+            assert host.check_output('mysql --version') == 'mysql  Ver 14.14 Distrib '+pxc57_client_version+', for Linux (x86_64) using  7.0'
         else:
             assert host.check_output('mysql --version') == 'mysql  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+ pxc_rel +', Revision '+ pxc_revision +', WSREP version '+ pxc_wsrep_version +')'
 
     def test_mysqld_version(self, host):
         if pxc_version_major in ['5.7','5.6']:
-            assert host.check_output('mysqld --version') == 'mysqld  Ver '+pxc_version+' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+pxc_version_percona+', Revision '+pxc_revision+')'
+            assert host.check_output('mysqld --version') == 'mysqld  Ver '+pxc57_server_version_norel+' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release '+pxc57_server_release+', Revision '+pxc_revision+', WSREP version '+ pxc_wsrep_version +', wsrep_'+ pxc_wsrep_version +')'
         else:
             assert host.check_output('mysqld --version') == '/usr/sbin/mysqld  Ver '+ pxc_version +' for Linux on x86_64 (Percona XtraDB Cluster (GPL), Release rel'+ pxc_rel +', Revision '+ pxc_revision +', WSREP version '+ pxc_wsrep_version +')'
 

--- a/docker-image-tests/pxc/tests/test_pxc_static.py
+++ b/docker-image-tests/pxc/tests/test_pxc_static.py
@@ -12,7 +12,11 @@ container_name = 'pxc-docker-test-static'
 def host():
     docker_id = subprocess.check_output(
         ['docker', 'run', '--name', container_name, '-e', 'MYSQL_ROOT_PASSWORD='+pxc_pwd, '-d', docker_image]).decode().strip()
-    subprocess.check_call(['docker','exec','--user','root',container_name,'yum','install','-y','net-tools'])
+    if pxc_version_major in ['5.7','5.6']:
+        exec_command = ['microdnf', 'install', 'net-tools']
+    else:
+        exec_command = ['yum', 'install', '-y', 'net-tools']
+    subprocess.check_call(['docker','exec','--user','root',container_name] + exec_command)
     time.sleep(20)
     yield testinfra.get_host("docker://root@" + docker_id)
     subprocess.check_call(['docker', 'rm', '-f', docker_id])

--- a/docker-image-tests/pxc/tests/test_pxc_static.py
+++ b/docker-image-tests/pxc/tests/test_pxc_static.py
@@ -23,10 +23,10 @@ def host():
 
 
 class TestMysqlEnvironment:
-    @pytest.mark.parametrize("pkg_name", pxc_packages)
-    def test_packages(self, host, pkg_name):
+    @pytest.mark.parametrize("pkg_name,pkg_version", pxc_packages)
+    def test_packages(self, host, pkg_name, pkg_version):
         assert host.package(pkg_name).is_installed
-        assert host.package(pkg_name).version == pxc_version_upstream
+        assert host.package(pkg_name).version == pkg_version
 
     @pytest.mark.parametrize("binary", pxc_binaries)
     def test_binaries_exist(self, host, binary):


### PR DESCRIPTION
This PR fixes the docker image tests for PXC 5.7 by doing the following:

- Correcting the package versions and binaries that are checked for under 5.7
- Fixing how the cluster is initialised for 5.7
- Changing the expected version number to match the one in 5.7 CentOS packages