### PR TITLE
Disambiguate "--password" option with "--options-password"

### DIFF
--- a/molecule/ps-innodb-cluster-router/tasks/main.yml
+++ b/molecule/ps-innodb-cluster-router/tasks/main.yml
@@ -76,10 +76,10 @@
       seconds: 10
 
   - name: add slave1
-    shell: mysqlsh --uri=root@ps-node1 --password=Test1234# -- cluster add-instance root@ps-node2:3306 --password=Test1234# --recoveryMethod=clone
+    shell: mysqlsh --uri=root@ps-node1 --password=Test1234# -- cluster add-instance root@ps-node2:3306 --options-password=Test1234# --recoveryMethod=clone
 
   - name: add slave2
-    shell: mysqlsh --uri=root@ps-node1 --password=Test1234# -- cluster add-instance root@ps-node3:3306 --password=Test1234# --recoveryMethod=clone
+    shell: mysqlsh --uri=root@ps-node1 --password=Test1234# -- cluster add-instance root@ps-node3:3306 --options-password=Test1234# --recoveryMethod=clone
 
   - name: bootstrap router
     shell: echo "Test1234#" | sudo mysqlrouter --bootstrap root@ps-node1 --user=mysqlrouter


### PR DESCRIPTION
This fixes the PS InnoDB Cluster tests when using recent versions of mysql-shell, which expect `--options-password` or `--instance-password` to be used with `add-instance`, instead of `--password`.