### PR TITLE
Use `main` repo for PXC bootstrap and `testing` for common/upgrade

### DIFF
--- a/playbooks/pxc80_bootstrap.yml
+++ b/playbooks/pxc80_bootstrap.yml
@@ -22,13 +22,8 @@
     with_items:
     - wget --no-check-certificate -P /package-testing https://raw.githubusercontent.com/Percona-QA/percona-qa/master/sample_db/world.sql
 
-  - name: include tasks for enabling test repo
-    include_tasks: ../tasks/enable_pxc80_testing_repo.yml
-    when: lookup('env', 'install_repo') == "testing" 
-
   - name: include tasks for enabling main repo
     include: ../tasks/enable_pxc80_main_repo.yml
-    when: lookup('env', 'install_repo') == "main" or lookup('env', 'install_repo') == ""
 
   - name: install python3-libselinux 
     yum:

--- a/playbooks/pxc80_common.yml
+++ b/playbooks/pxc80_common.yml
@@ -24,11 +24,6 @@
 
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc80_testing_repo.yml
-    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
-
-  - name: include tasks for enabling main repo
-    include: ../tasks/enable_pxc80_main_repo.yml
-    when: lookup('env', 'install_repo') == "main"
 
 # - name: disable selinux
 #   selinux: 

--- a/playbooks/pxc80_upgrade.yml
+++ b/playbooks/pxc80_upgrade.yml
@@ -8,11 +8,6 @@
   tasks:
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc80_testing_repo.yml
-    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
-
-  - name: include tasks for enabling main repo
-    include: ../tasks/enable_pxc80_main_repo.yml
-    when: lookup('env', 'install_repo') == "main"
 
   - name: upgrade PXC 8.0 to new deb packages
     apt:


### PR DESCRIPTION
This PR hardcodes the PXC package-testing tests to always use `main` on the bootstrap playbook and `testing` for the common/upgrade playbooks, disregarding the `install_repo` environment variable.

This fixes an issue where the upgrade playbook would not actually test the upgrade, since `install_repo` always has the same value for a given Jenkins build, meaning it would attempt to upgrade from `main` to `main` or from `testing` to `testing`, which is a no-op.