### PR TITLE
PXC-3742: Split "install" and "upgrade" playbooks for PXC

### DIFF
--- a/playbooks/pxc56_bootstrap.yml
+++ b/playbooks/pxc56_bootstrap.yml
@@ -117,5 +117,5 @@
 
   - name: check PXC 5.6 version
     command: /package-testing/version_check.sh pxc56
-    when: lookup('env', 'install_repo') == "main"
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 

--- a/playbooks/pxc56_bootstrap.yml
+++ b/playbooks/pxc56_bootstrap.yml
@@ -22,8 +22,17 @@
     with_items:
     - wget --no-check-certificate -P /package-testing https://raw.githubusercontent.com/Percona-QA/percona-qa/master/sample_db/world.sql
 
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing"
+
   - name: include tasks for enabling main repo
     include: ../tasks/enable_main_repo.yml
+    when: lookup('env', 'install_repo') == "main" or lookup('env', 'install_repo') == ""
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_experimental_repo.yml
+    when: lookup('env', 'install_repo') == "experimental"
 
   - name: disable selinux
     selinux: state=disabled

--- a/playbooks/pxc56_common.yml
+++ b/playbooks/pxc56_common.yml
@@ -17,8 +17,17 @@
   - name: include tasks for test env setup
     include: ../tasks/test_prep.yml
 
-  - name: include tasks for enabling testing repo
-    include: ../tasks/enable_testing_repo.yml
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
+
+  - name: include tasks for enabling main repo
+    include: ../tasks/enable_main_repo.yml
+    when: lookup('env', 'install_repo') == "main"
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_experimental_repo.yml
+    when: lookup('env', 'install_repo') == "experimental"
 
   - name: disable selinux
     selinux: state=disabled

--- a/playbooks/pxc56_common.yml
+++ b/playbooks/pxc56_common.yml
@@ -92,9 +92,11 @@
 
   - name: check that PXC version is correct
     command: /package-testing/version_check.sh pxc56
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 
   - name: check that PXC package versions are correct
     command: /package-testing/package_check.sh pxc56
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 
   - name: run bats tests for mysql init scripts
     command: /usr/local/bin/bats /package-testing/bats/pxc-init-scripts.bats

--- a/playbooks/pxc56_upgrade.yml
+++ b/playbooks/pxc56_upgrade.yml
@@ -6,8 +6,18 @@
   become_method: sudo
 
   tasks:
-  - name: include tasks for enabling testing repo
-    include: ../tasks/enable_testing_repo.yml
+
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_testing_repo.yml
+    when: lookup('env', 'upgrade_repo') == "testing" or lookup('env', 'upgrade_repo') == ""
+
+  - name: include tasks for enabling main repo
+    include: ../tasks/enable_main_repo.yml
+    when: lookup('env', 'upgrade_repo') == "main"
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_experimental_repo.yml
+    when: lookup('env', 'upgrade_repo') == "experimental"
 
 # restart the bootstrapped node before upgrading
 #

--- a/playbooks/pxc57_bootstrap.yml
+++ b/playbooks/pxc57_bootstrap.yml
@@ -162,5 +162,5 @@
 
   - name: check PXC 5.7 version
     command: /package-testing/version_check.sh pxc57
-    when: lookup('env', 'install_repo') == "main"
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 

--- a/playbooks/pxc57_bootstrap.yml
+++ b/playbooks/pxc57_bootstrap.yml
@@ -22,8 +22,17 @@
     with_items:
     - wget --no-check-certificate -P /package-testing https://raw.githubusercontent.com/Percona-QA/percona-qa/master/sample_db/world.sql
 
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_pxc57_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing"
+
   - name: include tasks for enabling main repo
     include: ../tasks/enable_pxc57_main_repo.yml
+    when: lookup('env', 'install_repo') == "main" or lookup('env', 'install_repo') == ""
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_pxc57_experimental_repo.yml
+    when: lookup('env', 'install_repo') == "experimental"
 
   - name: disable selinux
     selinux: state=disabled

--- a/playbooks/pxc57_common.yml
+++ b/playbooks/pxc57_common.yml
@@ -111,9 +111,11 @@
 
   - name: check that PXC version is correct
     command: /package-testing/version_check.sh pxc57
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 
   - name: check that PXC package versions are correct
     command: /package-testing/package_check.sh pxc57
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 
   - name: run bats tests for mysql init scripts
     command: /usr/local/bin/bats /package-testing/bats/pxc-init-scripts.bats

--- a/playbooks/pxc57_common.yml
+++ b/playbooks/pxc57_common.yml
@@ -17,8 +17,17 @@
   - name: include tasks for test env setup
     include: ../tasks/test_prep.yml
 
-  - name: include tasks for enabling testing repo
-    include: ../tasks/enable_pxc57_testing_repo.yml
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_pxc57_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
+
+  - name: include tasks for enabling main repo
+    include: ../tasks/enable_pxc57_main_repo.yml
+    when: lookup('env', 'install_repo') == "main"
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_pxc57_experimental_repo.yml
+    when: lookup('env', 'install_repo') == "experimental"
 
 # - name: include tasks for enabling experimental repo
 #   include: ../tasks/enable_pxc57_experimental_repo.yml

--- a/playbooks/pxc57_upgrade.yml
+++ b/playbooks/pxc57_upgrade.yml
@@ -6,12 +6,18 @@
   become_method: sudo
 
   tasks:
-     
-  - name: include tasks for enabling testing repo
-    include: ../tasks/enable_pxc57_testing_repo.yml
 
-# - name: include tasks for enabling experimental repo
-#   include: ../tasks/enable_pxc57_experimental_repo.yml
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_pxc57_testing_repo.yml
+    when: lookup('env', 'upgrade_repo') == "testing" or lookup('env', 'upgrade_repo') == ""
+
+  - name: include tasks for enabling main repo
+    include: ../tasks/enable_pxc57_main_repo.yml
+    when: lookup('env', 'upgrade_repo') == "main"
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_pxc57_experimental_repo.yml
+    when: lookup('env', 'upgrade_repo') == "experimental"
 
 # restart the bootstrapped node before upgrading
  

--- a/playbooks/pxc80_bootstrap.yml
+++ b/playbooks/pxc80_bootstrap.yml
@@ -118,5 +118,4 @@
 
   - name: check PXC 8.0 version
     command: /package-testing/version_check.sh pxc80
-    when: lookup('env', 'install_repo') == "main"
-
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""

--- a/playbooks/pxc80_bootstrap.yml
+++ b/playbooks/pxc80_bootstrap.yml
@@ -30,6 +30,10 @@
     include: ../tasks/enable_pxc80_main_repo.yml
     when: lookup('env', 'install_repo') == "main" or lookup('env', 'install_repo') == ""
 
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_pxc80_experimental_repo.yml
+    when: lookup('env', 'install_repo') == "experimental"
+
   - name: install python3-libselinux 
     yum:
       name: "{{ packages }}"

--- a/playbooks/pxc80_bootstrap.yml
+++ b/playbooks/pxc80_bootstrap.yml
@@ -22,8 +22,13 @@
     with_items:
     - wget --no-check-certificate -P /package-testing https://raw.githubusercontent.com/Percona-QA/percona-qa/master/sample_db/world.sql
 
+  - name: include tasks for enabling test repo
+    include_tasks: ../tasks/enable_pxc80_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing" 
+
   - name: include tasks for enabling main repo
     include: ../tasks/enable_pxc80_main_repo.yml
+    when: lookup('env', 'install_repo') == "main" or lookup('env', 'install_repo') == ""
 
   - name: install python3-libselinux 
     yum:

--- a/playbooks/pxc80_common.yml
+++ b/playbooks/pxc80_common.yml
@@ -98,9 +98,11 @@
 
   - name: check that PXC version is correct
     command: /package-testing/version_check.sh pxc80
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 
   - name: check that PXC package versions are correct
     command: /package-testing/package_check.sh pxc80
+    when: lookup('env', 'check_version') == "yes" or lookup('env', 'check_version') == ""
 
 # - name: install plugins
 #   command: /package-testing/plugins_test_80.sh pxc

--- a/playbooks/pxc80_common.yml
+++ b/playbooks/pxc80_common.yml
@@ -30,6 +30,10 @@
     include: ../tasks/enable_pxc80_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_pxc80_experimental_repo.yml
+    when: lookup('env', 'install_repo') == "experimental"
+
 # - name: disable selinux
 #   selinux: 
 #     policy: targeted

--- a/playbooks/pxc80_common.yml
+++ b/playbooks/pxc80_common.yml
@@ -24,6 +24,11 @@
 
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc80_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
+
+  - name: include tasks for enabling main repo
+    include: ../tasks/enable_pxc80_main_repo.yml
+    when: lookup('env', 'install_repo') == "main"
 
 # - name: disable selinux
 #   selinux: 

--- a/playbooks/pxc80_upgrade.yml
+++ b/playbooks/pxc80_upgrade.yml
@@ -8,11 +8,11 @@
   tasks:
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc80_testing_repo.yml
-    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
+    when: lookup('env', 'upgrade_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
     include: ../tasks/enable_pxc80_main_repo.yml
-    when: lookup('env', 'install_repo') == "main"
+    when: lookup('env', 'upgrade_repo') == "main"
 
   - name: upgrade PXC 8.0 to new deb packages
     apt:

--- a/playbooks/pxc80_upgrade.yml
+++ b/playbooks/pxc80_upgrade.yml
@@ -8,6 +8,11 @@
   tasks:
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc80_testing_repo.yml
+    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
+
+  - name: include tasks for enabling main repo
+    include: ../tasks/enable_pxc80_main_repo.yml
+    when: lookup('env', 'install_repo') == "main"
 
   - name: upgrade PXC 8.0 to new deb packages
     apt:

--- a/playbooks/pxc80_upgrade.yml
+++ b/playbooks/pxc80_upgrade.yml
@@ -8,11 +8,15 @@
   tasks:
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc80_testing_repo.yml
-    when: lookup('env', 'upgrade_repo') == "testing" or lookup('env', 'install_repo') == ""
+    when: lookup('env', 'upgrade_repo') == "testing" or lookup('env', 'upgrade_repo') == ""
 
   - name: include tasks for enabling main repo
     include: ../tasks/enable_pxc80_main_repo.yml
     when: lookup('env', 'upgrade_repo') == "main"
+
+  - name: include tasks for enabling experimental repo
+    include: ../tasks/enable_pxc80_experimental_repo.yml
+    when: lookup('env', 'upgrade_repo') == "experimental"
 
   - name: upgrade PXC 8.0 to new deb packages
     apt:


### PR DESCRIPTION
This PR is part of PXC-3742. It allows for splitting the PXC "install" and "upgrade" test runs, allowing for testing installation of the PXC version from any repo, as well as upgrade to the PXC version from any repo. It reverts the temporary fix in #92 and extends the functionality that existed before that PR to cover the experimental repo and PXC 5.7/5.6.

The main change in this PR is the addition of the `upgrade_repo` environment variable, separate from the existing `install_repo` environment variable, so that different repos can be used for install and upgrade.

On the Jenkins side, the matrix has been extended to parameterise over the "install" and "upgrade" test types. On the install test, the `install_repo` environment variable is set to the value of the corresponding build parameter, while on the upgrade test, `install_repo` is always set to "main" and `upgrade_repo` is set to the value of the build parameter. Builds where the build parameter is "main" will automatically skip performing the upgrade test. [The changes to the Jenkins script can be seen in this JobConfigHistory diff.](https://jenkins.percona.com/view/RT/job/package-testing-pxc/jobConfigHistory/showDiffFiles?timestamp1=2021-07-06_08-44-05&timestamp2=2021-08-25_08-48-54)