### PR TITLE
ENG-1056: change install word to remove in description/names of remove_*.yml tasks

### DIFF
--- a/tasks/remove_ps56.yml
+++ b/tasks/remove_ps56.yml
@@ -1,4 +1,4 @@
-# This task installs Percona Server 5.6 packages on CentOS and Debian/Ubuntu
+# This task removes Percona Server 5.6 packages on CentOS and Debian/Ubuntu
 #
 
   - name: remove Percona Server 5.6 deb packages

--- a/tasks/remove_ps80.yml
+++ b/tasks/remove_ps80.yml
@@ -1,7 +1,7 @@
-# This task installs Percona Server 8.0 on CentOS and Debian/Ubuntu
+# This task removes Percona Server 8.0 on CentOS and Debian/Ubuntu
 #
 
-  - name: install Percona Server deb packages
+  - name: remove Percona Server deb packages
     apt:
       name: "{{ packages }}"
       update_cache: yes
@@ -17,7 +17,7 @@
       - percona-server-rocksdb
     when: ansible_os_family == "Debian"
 
-  - name: install Percona Server rpm packages
+  - name: remove Percona Server rpm packages
     yum:
       name: "{{ packages }}"
       state: absent

--- a/tasks/remove_pt.yml
+++ b/tasks/remove_pt.yml
@@ -1,7 +1,7 @@
-# This task installs Percona Toolkit
+# This task removes Percona Toolkit
 #
 
-  - name: install Percona Toolkit new deb packages
+  - name: remove Percona Toolkit new deb packages
     apt:
       name: "{{ packages }}"
       update_cache: yes
@@ -11,7 +11,7 @@
       - percona-toolkit
     when: ansible_os_family == "Debian"
 
-  - name: install Percona Toolkit new rpm packages
+  - name: remove Percona Toolkit new rpm packages
     yum:
       name: "{{ packages }}"
       state: absent

--- a/tasks/remove_pxb24.yml
+++ b/tasks/remove_pxb24.yml
@@ -1,6 +1,6 @@
-# This task install Percona XtraBackup 2.4 on CentOS and Debian/Ubuntu
+# This task removes Percona XtraBackup 2.4 on CentOS and Debian/Ubuntu
 #
-  - name: install Percona XtraBackup new deb packages
+  - name: remove Percona XtraBackup new deb packages
     apt:
       name: "{{ packages }}"
       update_cache: yes
@@ -12,7 +12,7 @@
       - percona-xtrabackup-dbg-24
     when: ansible_os_family == "Debian"
 
-  - name: install Percona XtraBackup new rpm packages
+  - name: remove Percona XtraBackup new rpm packages
     yum:
       name: "{{ packages }}"
       state: absent

--- a/tasks/remove_pxb80.yml
+++ b/tasks/remove_pxb80.yml
@@ -1,6 +1,6 @@
-# This task install Percona XtraBackup 8.0 on CentOS and Debian/Ubuntu
+# This task removes Percona XtraBackup 8.0 on CentOS and Debian/Ubuntu
 #
-  - name: install Percona XtraBackup new deb packages
+  - name: remove Percona XtraBackup new deb packages
     apt:
       name: "{{ packages }}"
       update_cache: yes
@@ -12,7 +12,7 @@
       - percona-xtrabackup-dbg-80
     when: ansible_os_family == "Debian"
 
-  - name: install Percona XtraBackup new rpm packages
+  - name: remove Percona XtraBackup new rpm packages
     yum:
       name: "{{ packages }}"
       state: absent


### PR DESCRIPTION
There is a "misprint" in tasks/remove_*.yml tasks - the install is used in descriptions/names of tasks instead of remove which can mislead.