### PR TITLE
PXC-3828 implement selection of original/pxc-57 repo for pxc57 package testing

### DIFF
--- a/tasks/enable_pxc57_experimental_repo.yml
+++ b/tasks/enable_pxc57_experimental_repo.yml
@@ -14,14 +14,21 @@
     yum: name=https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     when: ansible_os_family == "RedHat"
 
-  - name: change the default repo to experimental
+  - name: change the default repo to pxc-57 experimental
     command: percona-release enable pxc-57 experimental
+    when: lookup('env', 'pxc57repo') == "pxc57" or lookup('env', 'pxc57repo') == ""
 
   - name: enable pxb24 repo
     command: percona-release enable pxb-24 release
+    when: lookup('env', 'pxc57repo') == "pxc57" or lookup('env', 'pxc57repo') == ""
 
   - name: add the experimental tools repo
     command: percona-release enable tools experimental
+    when: lookup('env', 'pxc57repo') == "pxc57" or lookup('env', 'pxc57repo') == ""
+
+  - name: enable original experimental repo
+    command: percona-release enable original experimental
+    when: lookup('env', 'pxc57repo') == "original"
 
   - name: clean and update yum cache
     shell: |

--- a/tasks/enable_pxc57_main_repo.yml
+++ b/tasks/enable_pxc57_main_repo.yml
@@ -17,11 +17,22 @@
     yum: name=https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     when: ansible_os_family == "RedHat"
 
-  - name: enable main repo
+  - name: enable original main repo
     command: percona-release enable original release
-#
-#  - name: enable pxb24 repo
-#    command: percona-release enable pxb-24 release
+    when: lookup('env', 'pxc57repo') == "original"
+
+  - name: enable pxc-57 main repo
+    command: percona-release enable-only pxc-57 release
+    when: lookup('env', 'pxc57repo') == "pxc57"
+
+# leaving for backward compitability before implementing original and pxc57 selection
+  - name: enable main repo
+    command: percona-release enable pxc-57 release
+    when: lookup('env', 'pxc57repo') == ""
+
+  - name: enable pxb24 repo
+    command: percona-release enable pxb-24 release
+    when: lookup('env', 'pxc57repo') == "pxc57" or lookup('env', 'pxc57repo') == ""
 
   - name: clean and update yum cache
     shell: |

--- a/tasks/enable_pxc57_testing_repo.yml
+++ b/tasks/enable_pxc57_testing_repo.yml
@@ -16,15 +16,21 @@
     yum: name=https://repo.percona.com/yum/percona-release-latest.noarch.rpm
     when: ansible_os_family == "RedHat"
 
-  - name: change the default repo to testing
+  - name: change the default repo to original testing
     command: percona-release enable-only original testing
+    when: lookup('env', 'pxc57repo') == "original"
 
   - name: enable original release repo for qpress dependancy for RHEL
     command: percona-release enable original release
-    when: ansible_os_family == "RedHat"
+    when: (ansible_os_family == "RedHat") and (lookup('env', 'pxc57repo') == "original")
+
+  - name: change the default repo to pxc-57 testing
+    command: percona-release enable-only pxc-57 testing
+    when: lookup('env', 'pxc57repo') == "pxc57" or lookup('env', 'pxc57repo') == ""
 
   - name: enable pxb24 repo
     command: percona-release enable pxb-24 release
+    when: lookup('env', 'pxc57repo') == "pxc57" or lookup('env', 'pxc57repo') == ""
 
   - name: clean and update yum cache
     shell: |


### PR DESCRIPTION
At the moment pxc-57 packages are located in 2 repos:
- pxc-57
- original.
Package testing Jenkins job https://jenkins.percona.com/view/RT/job/package-testing-pxc/ used pxc-57 and pxb-24 repos for tests. The new parameter will be added to Jenkins job: pxc57_repo (exported as $pxc57repo).
 Depending on its value the following repos will be enabled:
- if pxc57_repo = pxc57 or is empty: pxc-57 and pxb-24 repos;
- if pxc57_repo = original: original repo.
Some notes:
- as qpress packages are not present in original testing yum repo, original release repo is also enabled for tests in  enable_pxc57_testing_repo.yml ( see https://jira.percona.com/browse/PXC-3813 );
The link to task with tests: https://jenkins.percona.com/view/RT/job/eleonora-package-testing-pxc/