### PR TITLE
Update upstream repo package and gpg key for PXB package tests.

### DIFF
--- a/playbooks/pxb_24_upstream.yml
+++ b/playbooks/pxb_24_upstream.yml
@@ -31,7 +31,7 @@
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
 
   - name: Install MySQL RHEL 7 yum repository package
-    yum: name=https://dev.mysql.com/get/mysql80-community-release-el7-2.noarch.rpm state=present
+    yum: name=https://dev.mysql.com/get/mysql80-community-release-el7-5.noarch.rpm state=present
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
     # Note: Mysql 5.7 packages for RHEL8/CentOS8 do not exist in mysql80-community-release-el8-1.noarch.rpm, hence we can't run the upstream script for CentOS8 till the packages are available. Uncomment following section after MS5.7 packages are available for Centos8.

--- a/playbooks/pxb_80_upstream.yml
+++ b/playbooks/pxb_80_upstream.yml
@@ -14,7 +14,7 @@
 
   - name: Install MySQL apt repository package
     apt:
-      deb: https://dev.mysql.com/get/mysql-apt-config_0.8.12-1_all.deb
+      deb: https://dev.mysql.com/get/mysql-apt-config_0.8.22-1_all.deb
     when: ansible_os_family == "Debian"
 
   - name: Install MySQL RHEL 6 yum repository package
@@ -22,17 +22,17 @@
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "6"
 
   - name: Install MySQL RHEL 7 yum repository package
-    yum: name=https://dev.mysql.com/get/mysql80-community-release-el7-1.noarch.rpm state=present
+    yum: name=https://dev.mysql.com/get/mysql80-community-release-el7-5.noarch.rpm state=present
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "7"
 
   - name: Import key for mysql-repo
     rpm_key:
       state: present
-      key: http://repo.mysql.com/RPM-GPG-KEY-mysql
+      key: http://repo.mysql.com/RPM-GPG-KEY-mysql-2022
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: Install MySQL RHEL 8 yum repository package
-    yum: name=https://dev.mysql.com/get/mysql80-community-release-el8-1.noarch.rpm state=present
+    yum: name=https://dev.mysql.com/get/mysql80-community-release-el8-3.noarch.rpm state=present
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
   - name: epel 7 repo


### PR DESCRIPTION
The upstream keys have changed in 2022. The repo package and yum gpg key links were updated.