### PR TITLE
Use vault.centos.org archive instead of mirrors for CentOS8

### DIFF
--- a/Vagrantfile.template.normal
+++ b/Vagrantfile.template.normal
@@ -9,6 +9,7 @@ servers=[
   { :hostname => "centos-6-64-@@hostname@@", :box => "bento/centos-6" },
   { :hostname => "centos-7-64-@@hostname@@", :box => "bento/centos-7" },
   { :hostname => "centos-8-64-@@hostname@@", :box => "bento/centos-8" },
+  { :hostname => "oracle-linux-8-64-@@hostname@@", :box => "bento/oracle-8" },
   { :hostname => "rocky-8-64-@@hostname@@", :box => "bento/rockylinux-8" },
   { :hostname => "amazonlinux-2-64-@@hostname@@", :box => "bento/amazonlinux-2" },
   { :hostname => "rhel-8-64-@@hostname@@", :box => "generic/rhel8" },

--- a/tasks/test_prep.yml
+++ b/tasks/test_prep.yml
@@ -23,6 +23,10 @@
      key: https://repo.percona.com/yum/RPM-GPG-KEY-Percona
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
+  - name: update mirrors for CentOS8
+    shell: sed -i 's/mirror\.centos\.org/vault\.centos\.org/g;s/\#baseurl=/baseurl=/g;s/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS*.repo
+    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
   - name: setup epel 8 repo
     yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm state=present
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"

--- a/tasks/test_prep.yml
+++ b/tasks/test_prep.yml
@@ -25,7 +25,7 @@
 
   - name: update mirrors for CentOS8
     shell: sed -i 's/mirror\.centos\.org/vault\.centos\.org/g;s/\#baseurl=/baseurl=/g;s/mirrorlist=/#mirrorlist=/g' /etc/yum.repos.d/CentOS*.repo
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+    when: ansible_distribution == "CentOS" and ansible_distribution_major_version == "8"
 
   - name: setup epel 8 repo
     yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm state=present


### PR DESCRIPTION
Based on https://www.centos.org/centos-linux-eol/#:~:text=CentOS%20Linux%208%20will%20reach%20End%20Of%20Life%20(EOL)%20on,Stream%208%20in%20this%20case CenOS8 mirrors are not available any more. That is why CentOS8 package testing will fail. To fix it the mirrors should be replaced with vault.centos.org .