### PR TITLE
Remove Xenial and Centos6 distribution from Binary Tarball Test Job

### DIFF
--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -41,20 +41,6 @@ pipeline {
             junit 'package-testing/binary-tarball-tests/ps/report.xml'
           } //End steps
         } //End stage Ubuntu Bionic
-        stage('Ubuntu Xenial') {
-          agent {
-            label "min-xenial-x64"
-          }
-          steps {
-            script {
-                currentBuild.displayName = "#${BUILD_NUMBER}-${PS_VERSION}-${PS_REVISION}"
-              }
-            withCredentials([usernamePassword(credentialsId: 'JenkinsAPI', passwordVariable: 'JENKINS_API_PWD', usernameVariable: 'JENKINS_API_USER')]) {
-              run_test()
-            }
-            junit 'package-testing/binary-tarball-tests/ps/report.xml'
-          } //End steps
-        } //End stage Ubuntu Xenial
         stage('Debian Bullseye') {
           agent {
             label "min-bullseye-x64"
@@ -125,20 +111,6 @@ pipeline {
             junit 'package-testing/binary-tarball-tests/ps/report.xml'
           } //End steps
         } //End stage Centos7
-        stage('Centos6') {
-          agent {
-            label "min-centos-6-x64"
-          }
-          steps {
-            script {
-                currentBuild.displayName = "#${BUILD_NUMBER}-${PS_VERSION}-${PS_REVISION}"
-              }
-            withCredentials([usernamePassword(credentialsId: 'JenkinsAPI', passwordVariable: 'JENKINS_API_PWD', usernameVariable: 'JENKINS_API_USER')]) {
-              run_test()
-            }
-            junit 'package-testing/binary-tarball-tests/ps/report.xml'
-          } //End steps
-        } //End stage Centos6
       } //End parallel
     } //End stage Run tests
   } //End stages
@@ -169,7 +141,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
+    git clone https://github.com/kaushikpuneet07/package-testing.git --branch cleanup --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true

--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -141,7 +141,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/kaushikpuneet07/package-testing.git --branch cleanup --depth 1
+    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true


### PR DESCRIPTION
Remove Xenial and Centos6 distribution from Binary Tarball Test Job as it is EOL now.