### PR TITLE
Fixed GLIBC Version in tarball job

### DIFF
--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -152,24 +152,16 @@ void run_test() {
     if [ "${BUILD_TYPE_MINIMAL}" = "true" ]; then
       MINIMAL="-minimal"
     fi
-    if [ "${PS_MAJOR_VERSION}" = "8.0" ]; then
-      export GLIBC_VERSION="2.17"
-      if [ -f /etc/redhat-release ] && [ $(grep -c "release 6" /etc/redhat-release) -eq 1 ]; then
-        export GLIBC_VERSION="2.12"
-      fi
-      TARBALL_NAME="Percona-Server-${PS_VERSION}-Linux.x86_64.glibc${GLIBC_VERSION}${MINIMAL}.tar.gz"
-      TARBALL_LINK="https://www.percona.com/downloads/TESTING/ps-${PS_VERSION}/"
-    elif [ "${PS_MAJOR_VERSION}" = "5.7" ]; then
-      TARBALL_NAME="Percona-Server-${PS_VERSION}-Linux.x86_64.glibc2.12${MINIMAL}.tar.gz"
-      TARBALL_LINK="https://www.percona.com/downloads/TESTING/ps-${PS_VERSION}/"
-    fi
+    export GLIBC_VERSION="2.17"
+    TARBALL_NAME="Percona-Server-${PS_VERSION}-Linux.x86_64.glibc${GLIBC_VERSION}${MINIMAL}.tar.gz"
+    TARBALL_LINK="https://www.percona.com/downloads/TESTING/ps-${PS_VERSION}/"
     rm -rf package-testing
     if [ -f /usr/bin/yum ]; then
       sudo yum install -y git wget
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
+    git clone https://github.com/kaushikpuneet07/package-testing.git --branch tarball --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true

--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -161,7 +161,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/kaushikpuneet07/package-testing.git --branch tarball --depth 1
+    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true


### PR DESCRIPTION
As GLIBC version 2.12 is not needed after Centos6 EOL , so removing the code for checking glibc version and hardcoded it to 2.12