### PR TITLE
Expand pxc80 binaries list for docker test

### DIFF
--- a/docker-image-tests/pxc/settings.py
+++ b/docker-image-tests/pxc/settings.py
@@ -35,7 +35,9 @@ pxc80_binaries = (
   '/usr/bin/mysql', '/usr/sbin/mysqld', '/usr/bin/mysqladmin',
   '/usr/bin/mysqldump', '/usr/bin/mysqldumpslow',
   '/usr/bin/mysql_secure_installation', '/usr/bin/mysql_ssl_rsa_setup', '/usr/bin/mysql_upgrade',
-  '/usr/bin/mysql_tzinfo_to_sql'
+  '/usr/bin/mysql_tzinfo_to_sql','/usr/bin/mysql_keyring_encryption_test','/usr/bin/mysql_migrate_keyring',
+  '/usr/bin/mysqld_multi','/usr/bin/mysqld_safe','/usr/bin/mysql-systemd',
+  '/usr/bin/mysqlbinlog'
 )
 pxc80_plugins = (
   ('audit_log','audit_log.so'),('mysql_no_login','mysql_no_login.so'),('validate_password','validate_password.so'),


### PR DESCRIPTION
The Docker image test for pxc80 checks presence of the binaries (https://pxc.cd.percona.com/view/QA%208.0/job/qa-docker-image/). The list of binaries is in docker-image-tests/pxc/settings.py file (pxc80_binaries list). The list did not include all the binaries that are present in docker image for pxc80, that is why it was extended to include missing binaries.

Test run with the updated list of binaries: https://pxc.cd.percona.com/view/QA%208.0/job/qa-docker-image/123 .