### PR TITLE
Remove TokuDB and non-required tests

### DIFF
--- a/package_check.sh
+++ b/package_check.sh
@@ -95,6 +95,14 @@ if [ ${product} = "ps56" -o ${product} = "ps57" -o ${product} = "ps80" ]; then
     if [ "${product}" = "ps56" ]; then
       rpm_opt_package="Percona-Server-tokudb-${rpm_maj_version} Percona-Server-selinux-${rpm_maj_version}"
       rpm_num_pkgs="8"
+    elif [ "${product}" = "ps57" ] && [ "${ps57_tokudb}" = "no" ]; then
+      if [ "${centos_maj_version}" == "7" ]; then
+        rpm_num_pkgs="8"
+        rpm_opt_package="Percona-Server-rocksdb-${rpm_maj_version} Percona-Server-shared-compat-${rpm_maj_version}"
+      else
+        rpm_num_pkgs="7"
+        rpm_opt_package="Percona-Server-rocksdb-${rpm_maj_version}"
+      fi
     elif [ "${product}" = "ps57" ]; then
       if [ "${centos_maj_version}" == "7" ]; then
         rpm_num_pkgs="9"
@@ -129,17 +137,20 @@ if [ ${product} = "ps56" -o ${product} = "ps57" -o ${product} = "ps80" ]; then
     if [ ${product} = "ps56" ]; then
       deb_opt_package="percona-server-tokudb-${deb_maj_version}"
       deb_num_pkgs="7"
-    elif [ ${product} = "ps57" ]; then 
+    elif [ "${product}" = "ps57" ] && [ "${ps57_tokudb}" = "no" ]; then
+      deb_opt_package="percona-server-rocksdb-${deb_maj_version}"
+      deb_num_pkgs="7"
+    elif [ "${product}" = "ps57" ]; then
       deb_opt_package="percona-server-rocksdb-${deb_maj_version} percona-server-tokudb-${deb_maj_version}"
       deb_num_pkgs="8"
     else
       deb_opt_package="percona-server-rocksdb"
-      deb_num_pkgs="7"      
+      deb_num_pkgs="7"
     fi
     if [ "$(dpkg -l | grep percona-server | grep -c ${version})" == "${deb_num_pkgs}" ]; then
       echo "all packages are installed"
     else
-      for package in percona-server-server percona-server-client percona-server-test percona-server-dbg percona-server-source percona-server-common ${deb_opt_package}; do
+      for package in percona-server-server percona-server-client percona-server-test percona-server-${deb_maj_version}-dbg percona-server-source percona-server-common ${deb_opt_package}; do
         if [ "$(dpkg -l | grep ${package} | grep -c ${version})" != 0 ]; then
           echo "$(date +%Y%m%d%H%M%S): ${package} is installed"
         else

--- a/playbooks/common_57_major_upgrade_from.yml
+++ b/playbooks/common_57_major_upgrade_from.yml
@@ -45,8 +45,31 @@
     with_items:
     - wget --no-check-certificate -P /package-testing https://raw.githubusercontent.com/Percona-QA/percona-qa/master/sample_db/world.sql
 
+### install PS5.7 without TokuDB as PS8.0 do not support TokuDB
   - name: install Percona Server 5.7 packages
     include_tasks: ../tasks/install_ps57.yml
+    vars:
+      packages:
+      - percona-server-server-5.7
+      - percona-server-test-5.7
+      - percona-server-5.7-dbg
+      - percona-server-source-5.7
+      - percona-server-rocksdb-5.7
+    when: ansible_os_family == "Debian"
+
+### install PS5.7 without TokuDB as PS8.0 do not support TokuDB
+  - name: install Percona Server 5.7 packages
+    include_tasks: ../tasks/install_ps57.yml
+    vars:
+      packages:
+      - Percona-Server-server-57
+      - Percona-Server-test-57
+      - Percona-Server-57-debuginfo
+      - Percona-Server-devel-57
+      - Percona-Server-rocksdb-57
+      - Percona-Server-shared-57
+      - Percona-Server-client-57
+    when: ansible_os_family == "RedHat"
 
   - name: install Percona Toolkit new deb packages
     include_tasks: ../tasks/install_pt.yml
@@ -78,27 +101,12 @@
               mode=0640 owner=root group=root
     when: ansible_os_family == "RedHat"
 
-  - name: run PAM test
-    include_tasks: ../tasks/pam_test.yml
-
   - name: disable selinux on centos7 for TokuDB to work
     shell: setenforce 0 || true
     when: ansible_os_family == "RedHat"
 
-  - name: install tokudb and restart server
-    command: /usr/bin/ps_tokudb_admin --enable --enable-backup
-
   - name: restart mysql service
     service: name=mysql state=restarted
-
-  - name: re-run ps_tokudb_admin to finish tokudb install
-    command: /usr/bin/ps_tokudb_admin --enable --enable-backup
-
-  - name: install plugins, import world database, test tokudb
-    command: /package-testing/plugins_test_57.sh ps
-
-  - name: keyring plugins test
-    command: /package-testing/scripts/ps_keyring_plugins_test/ps_keyring_plugins_test.sh ps57
 
   - name: re-run ps_admin to install rocksdb
     command: /usr/bin/ps-admin --enable-rocksdb
@@ -108,6 +116,8 @@
 
   - name: check that Percona Server package versions are correct
     command: /package-testing/package_check.sh ps57
+    environment:
+      ps57_tokudb: "no"
 
 # - name: check that sysbench version is correct
 #   command: /package-testing/version_check.sh sysbench
@@ -120,24 +130,6 @@
   - name: check that Percona XtraBackup package versions are correct
     command: /package-testing/package_check.sh pxb24
     when: lookup('env', 'install_repo') != "experimental"
-
-  - name: run some MyRocks tests
-    command: /package-testing/scripts/ps_myrocks_test.sh
-
-  - name: run mysql compression tests script
-    command: /package-testing/scripts/mysql-comp-test/mysql_comp_test.sh ps57
-
-  - name: run bats unit tests for ps_tokudb_admin scripts
-    command: /usr/local/bin/bats /package-testing/bats/ps_tokudb_admin_unit.bats
-
-  - name: run bats integration tests for ps_tokudb_admin script
-    command: /usr/local/bin/bats /package-testing/bats/ps_tokudb_admin_integration.bats
-
-  - name: run bats unit tests for ps-admin script
-    command: /usr/local/bin/bats /package-testing/bats/ps-admin_unit.bats
-
-  - name: run bats integration tests for ps-admin script
-    command: /usr/local/bin/bats /package-testing/bats/ps-admin_integration.bats
 
   - name: install 3rd party packages with apt
     apt:
@@ -155,14 +147,8 @@
       - rsyslog-mysql
     when: ansible_os_family == "RedHat"
 
-  - name: run bats tests for mysql init scripts
-    command: /usr/local/bin/bats /package-testing/bats/mysql-init-scripts.bats
-
   - name: start mysql service
     service: name=mysql state=started
-
-  - name: upgrade partitioning
-    command: /package-testing/scripts/ps_upgrade_partitioning.sh
 
 # temporary commented out until BLD-906 is fixed
 # - name: check that mysqladmin shutdown works correctly
@@ -217,32 +203,13 @@
 
   - name: include tasks for enabling PS 8 main repo
     include: ../tasks/enable_ps8_main_repo.yml
-    when: lookup('env', 'install_repo') == "main"
-
-  - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
-    when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
-
-  - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
-    when: lookup('env', 'install_repo') == "experimental"
-
 
 #
 # Add TokuDB options so it can run
 #
 
-  - name: copy the TokuDB config file on Debian/Ubuntu
-    template: src=../templates/tokudb.j2 dest=/etc/mysql/conf.d/tokudb.cnf
-    when: ansible_os_family == "Debian"
-
-  - name: copy the TokuDB config file on RHEL/CentOS/Amazon
-    template: src=../templates/tokudb.j2 dest=/etc/my.cnf.d/tokudb.cnf
-    when: ansible_os_family == "RedHat"
-
-
-  - name: enable tools testing repo
-    command: percona-release enable tools testing
+  - name: enable tools repo
+    command: percona-release enable tools
 
   - name: install Percona Toolkit new deb packages
     include_tasks: ../tasks/install_pt.yml


### PR DESCRIPTION
At the moment major PS57 major update from update fails because PS80 does not support TokuDB any more. To overcome this issue the TokuDB installation was removed from common_57_major_upgrade_from.yml. In addition I have removed bat tests and compression ones for PS57 as they are also run in common_57.yml . 

I have adjusted package_check.sh script to skip TokuDB check if $ps57_tokudb = "no" and added it to common_57_major_upgrade_from.yml test only.