### PR TITLE
Add garbd check to pxc docker image test

### DIFF
--- a/docker-image-tests/pxc/tests/test_pxc_cluster.py
+++ b/docker-image-tests/pxc/tests/test_pxc_cluster.py
@@ -66,6 +66,58 @@ def cluster():
         node.destroy()
     subprocess.check_call(['docker', 'network', 'rm', docker_network])
 
+class GardbNode:
+    def __init__(self):
+        self.docker_image = "oraclelinux:8"
+        self.docker_name = 'ol8_node'
+        subprocess.check_call(['docker', 'pull', self.docker_image])
+        if pxc_version_major == "8.0":
+            self.docker_id = subprocess.check_output(['docker', 'run', '-d', '-i', '--name='+self.docker_name,
+            '--net='+docker_network, '-v', test_pwd+'/cert:/cert', self.docker_image]).decode().strip()
+        else:
+            self.docker_id = subprocess.check_output(['docker', 'run', '-d', '-i', '--name='+self.docker_name,
+            '--net='+docker_network, self.docker_image]).decode().strip()
+
+    def install_garbd(self):
+        if pxc_version_major == "5.7":
+            if docker_acc == 'percona':
+                self.repo_name = 'pxc-57'
+            else:
+                self.repo_name = 'pxc-57 testing'
+            self.image = 'Percona-XtraDB-Cluster-garbd-57'
+        else:
+            if docker_acc == 'percona':
+                self.repo_name = 'pxc-80'
+            else:
+                self.repo_name = 'pxc-80 testing'
+            self.image = 'percona-xtradb-cluster-garbd'
+        subprocess.check_call(['docker', 'exec', self.docker_name, 'yum', 'install', '-y', 'https://repo.percona.com/yum/percona-release-latest.noarch.rpm'])
+        subprocess.check_call(['docker', 'exec', self.docker_name, 'percona-release', 'enable', self.repo_name])
+        subprocess.check_call(['docker', 'exec', self.docker_name, 'rpm', '--import', 'https://repo.percona.com/yum/RPM-GPG-KEY-Percona'])
+        subprocess.check_call(['docker', 'exec', self.docker_name, 'rpm', '--import', 'https://repo.percona.com/yum/PERCONA-PACKAGING-KEY'])
+        subprocess.check_call(['docker', 'exec', self.docker_name, 'yum', 'install', '-y', self.image])
+
+    def connect_pxc(self):
+        self.pxc_ips = subprocess.check_output(['docker', 'inspect', '-f' '"{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}"',
+        base_node_name+'1', base_node_name+'2',base_node_name+'3']).decode().strip().replace('\n',',').replace('"','')
+        if pxc_version_major == "8.0":
+            subprocess.check_call(['docker', 'exec', '-d', self.docker_name, 'garbd', '--group='+cluster_name, '--address=gcomm://'+self.pxc_ips,
+            '--option="socket.ssl_key=/cert/server-key.pem; socket.ssl_cert=/cert/server-cert.pem; socket.ssl_ca=/cert/ca.pem; socket.ssl_cipher=AES128-SHA256"'])
+        else:
+            subprocess.check_call(['docker', 'exec', '-d', self.docker_name, 'garbd', '--group='+cluster_name, '--address=gcomm://'+self.pxc_ips])
+
+    def destroy(self):
+        subprocess.check_call(['docker', 'rm', '-f', self.docker_id])
+
+@pytest.fixture(scope='module')
+def garbd():
+    garbd = GardbNode()
+    garbd.install_garbd()
+    time.sleep(5)
+    garbd.connect_pxc()
+    time.sleep(30)
+    yield garbd
+    garbd.destroy()
 
 class TestCluster:
     @pytest.mark.parametrize("fname,soname,return_type", pxc_functions)
@@ -96,3 +148,13 @@ class TestCluster:
     def test_cluster_size(self, cluster):
         output = cluster[0].run_query('SHOW STATUS LIKE "wsrep_cluster_size";')
         assert output.split('\t')[1].strip() == "3"
+
+class TestGardb:
+    def test_cluster_size_at_startup(self, cluster, garbd):
+        output = cluster[0].run_query('SHOW STATUS LIKE "wsrep_cluster_size";')
+        assert output.split('\t')[1].strip() == "4"
+
+    def test_cluster_size_after_timeout(self, cluster, garbd):
+        time.sleep(360)
+        output = cluster[0].run_query('SHOW STATUS LIKE "wsrep_cluster_size";')
+        assert output.split('\t')[1].strip() == "4"


### PR DESCRIPTION
The test to check whether garbd can connect to pxc5.7/pxc8.0 cluster was added. The check is performed based on the number of nodes in the wsrep_cluster_size. The first check is performed on the the garbd connect and the second one is performed in 6 minutes. 
The test is performed:
1. Oracle Linux 8 image is downloaded;
2. garbd from repo is installed in ol8 container.
3. The number of nodes is checked.