### PR TITLE
PS-8281: libHotBackup.so error while running tarball job

### DIFF
--- a/binary-tarball-tests/ps/mysql.py
+++ b/binary-tarball-tests/ps/mysql.py
@@ -27,8 +27,12 @@ class MySQL:
             os.environ['LD_PRELOAD'] = self.basedir+'/lib/mysql/libjemalloc.so.1 '+self.basedir+'/lib/libHotBackup.so'
             self.psadmin = base_dir+'/bin/ps_tokudb_admin'
             subprocess.check_call([self.mysql_install_db, '--no-defaults', '--basedir='+self.basedir,'--datadir='+self.datadir])
-        else:
+        elif self.major_version == "5.7":
             os.environ['LD_PRELOAD'] = self.basedir+'/lib/mysql/libjemalloc.so.1 '+self.basedir+'/lib/libHotBackup.so'
+            self.psadmin = base_dir+'/bin/ps-admin'
+            subprocess.check_call([self.mysqld, '--no-defaults', '--initialize-insecure','--basedir='+self.basedir,'--datadir='+self.datadir])
+        else:
+            os.environ['LD_PRELOAD'] = self.basedir+'/lib/mysql/libjemalloc.so.1'
             self.psadmin = base_dir+'/bin/ps-admin'
             subprocess.check_call([self.mysqld, '--no-defaults', '--initialize-insecure','--basedir='+self.basedir,'--datadir='+self.datadir])
 

--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -133,7 +133,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
+    git clone https://github.com/kaushikpuneet07/package-testing.git --branch libhotbackup-error --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true

--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -133,7 +133,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/kaushikpuneet07/package-testing.git --branch libhotbackup-error --depth 1
+    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true


### PR DESCRIPTION
`ERROR: ld.so: object '/mnt/jenkins/workspace/test-ps-binary-tarball/package-testing/binary-tarball-tests/ps/Percona-Server-8.0.28-20-Linux.x86_64.glibc2.17/lib/libHotBackup.so' from LD_PRELOAD cannot be preloaded (cannot open shared object file): ignored.`