### PR TITLE
Use 3 rpm packages for orchestrator tests in pdps

### DIFF
--- a/molecule/pdmysql/pdps/molecule/tests/test_orchestrator.py
+++ b/molecule/pdmysql/pdps/molecule/tests/test_orchestrator.py
@@ -7,25 +7,13 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-DEBPACKAGES = ['percona-orchestrator-cli', 'percona-orchestrator-client', 'percona-orchestrator']
+PACKAGES = ['percona-orchestrator-cli', 'percona-orchestrator-client', 'percona-orchestrator']
 VERSION = os.getenv("ORCHESTRATOR_VERSION")
 
 
-@pytest.mark.parametrize("package", DEBPACKAGES)
-def test_check_deb_package(host, package):
-    dist = host.system_info.distribution
-    if dist.lower() in ["redhat", "centos", 'rhel']:
-        pytest.skip("This test only for Debian based platforms")
+@pytest.mark.parametrize("package", PACKAGES)
+def test_check_package(host, package):
     pkg = host.package(package)
-    assert pkg.is_installed
-    assert VERSION in pkg.version, pkg.version
-
-
-def test_check_rpm_package(host):
-    dist = host.system_info.distribution
-    if dist.lower() in ["debian", "ubuntu"]:
-        pytest.skip("This test only for RHEL based platforms")
-    pkg = host.package('percona-orchestrator')
     assert pkg.is_installed
     assert VERSION in pkg.version, pkg.version
 
@@ -41,8 +29,5 @@ def test_version(host):
 
 def test_client(host):
     cmd = 'orchestrator-client --help h'
-    dist = host.system_info.distribution
-    if dist.lower() in ["redhat", "centos", 'rhel']:
-        cmd = "/usr/local/orchestrator/resources/bin/orchestrator-client --help h"
     result = host.run(cmd)
     assert result.rc == 0, result.stderr

--- a/molecule/pdmysql/pdps/tasks/main.yml
+++ b/molecule/pdmysql/pdps/tasks/main.yml
@@ -110,8 +110,13 @@
 
   - name: install orchestrator rpm packages
     yum:
-      name: percona-orchestrator
+      name: "{{ packages }}"
       state: latest
+    vars:
+      packages:
+        - percona-orchestrator-cli
+        - percona-orchestrator-client
+        - percona-orchestrator
     when: ansible_os_family == "RedHat"
 
   - name: start mysql service


### PR DESCRIPTION
In scope of https://jira.percona.com/browse/DISTMYSQL-198 the rpm packages were updated as follows:
- instead of 1 package (percona-orchestrator) now 3 packages are installed : 
 * percona-orchestrator
 * percona-orchestrator-cli
 * percona-orchestrator-client
Now the 'percona-orchestrator-client' on rpm packages is no located in `/usr/bin/orchestrator-client` instead of `/usr/local/orchestrator/resources/bin/orchestrator-client` (the same as in upstream)