### PR TITLE
Fix rpm orchestrator pkgs, mysql-router and  mysql-shell version in pdps minor upgrade

### DIFF
--- a/molecule/pdmysql/pdps-minor-upgrade/molecule/tests/test_orchestrator.py
+++ b/molecule/pdmysql/pdps-minor-upgrade/molecule/tests/test_orchestrator.py
@@ -7,29 +7,16 @@ testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
     os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
 
 
-DEBPACKAGES = ['percona-orchestrator-cli', 'percona-orchestrator-client', 'percona-orchestrator']
+PACKAGES = ['percona-orchestrator-cli', 'percona-orchestrator-client', 'percona-orchestrator']
 
 VERSION = os.getenv("ORCHESTRATOR_VERSION")
 
 
-@pytest.mark.parametrize("package", DEBPACKAGES)
+@pytest.mark.parametrize("package", PACKAGES)
 def test_check_deb_package(host, package):
-    dist = host.system_info.distribution
-    if dist.lower() in ["redhat", "centos", 'rhel']:
-        pytest.skip("This test only for Debian based platforms")
     pkg = host.package(package)
     assert pkg.is_installed
     assert VERSION in pkg.version, pkg.version
-
-
-def test_check_rpm_package(host):
-    dist = host.system_info.distribution
-    if dist.lower() in ["debian", "ubuntu"]:
-        pytest.skip("This test only for RHEL based platforms")
-    pkg = host.package('percona-orchestrator')
-    assert pkg.is_installed
-    assert VERSION in pkg.version, pkg.version
-
 
 def test_orchestrator_version(host):
     cmd = 'orchestrator --version'
@@ -41,9 +28,6 @@ def test_orchestrator_version(host):
 
 
 def test_orchestrator_client(host):
-    cmd = 'orchestrator-client --help'
-    dist = host.system_info.distribution
-    if dist.lower() in ["redhat", "centos", 'rhel']:
-        cmd = "/usr/local/orchestrator/resources/bin/orchestrator-client --help"
+    cmd = 'orchestrator-client --help h'
     result = host.run(cmd)
     assert result.rc == 0, result.stderr

--- a/molecule/pdmysql/pdps-minor-upgrade/tasks/main.yml
+++ b/molecule/pdmysql/pdps-minor-upgrade/tasks/main.yml
@@ -20,7 +20,7 @@
     command: yum module disable mariadb -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8"
 
-  - name: Setup initial (old) repository
+  - name: Setup initial (old) repository pdps-{{ pdmysql_version }} {{ repo }}
     command: percona-release enable-only pdps-{{ pdmysql_version }} {{ repo }}
     vars:
       repo: "{{ lookup('env', 'FROM_REPO') }}"
@@ -105,8 +105,11 @@
 
   - name: install orchestrator rpm packages
     yum:
-      name: percona-orchestrator
+      name: "{{ packages }}"
       state: latest
+    vars:
+      packages:
+        - percona-orchestrator
     when: ansible_os_family == "RedHat"
 
   - name: start mysql service
@@ -117,10 +120,12 @@
     with_items:
     - rm -rf /package-testing
     - rm -f master.zip
-    - wget --no-check-certificate -O master.zip https://github.com/Percona-QA/package-testing/archive/master.zip
+    - wget --no-check-certificate -O master.zip "https://github.com/Percona-QA/package-testing/archive/{{ branch }}.zip"
     - unzip master.zip
     - rm -f master.zip
-    - mv package-testing-master /package-testing
+    - mv "package-testing-{{ branch }}" /package-testing
+    vars:
+      branch: "{{ lookup('env', 'TESTING_BRANCH') }}"
 
   - name: set root password on centos
     command: /package-testing/setpass_57.sh
@@ -168,13 +173,13 @@
   - name: start mysql service
     service: name=mysql state=started enabled=yes
 
-  - name: Disable old repository
+  - name: Disable old repository pdps-{{ pdmysql_version }} {{ repo }}
     command: percona-release disable pdps-{{ pdmysql_version }} {{ repo }}
     vars:
       repo: "{{ lookup('env', 'FROM_REPO') }}"
       pdmysql_version: "{{ lookup('env', 'FROM_VERSION') }}"
 
-  - name: Setup new repository
+  - name: Setup new repository pdps-{{ pdmysql_version }} {{ repo }}
     command: percona-release enable pdps-{{ pdmysql_version }} {{ repo }}
     vars:
       repo: "{{ lookup('env', 'TO_REPO') }}"
@@ -258,8 +263,13 @@
 
   - name: install orchestrator rpm packages
     yum:
-      name: percona-orchestrator
+      name: "{{ packages }}"
       state: latest
+    vars:
+      packages:
+        - percona-orchestrator-cli
+        - percona-orchestrator-client
+        - percona-orchestrator
     when: ansible_os_family == "RedHat"
 
   - name: start mysql service
@@ -271,6 +281,7 @@
   - name: install percona-mysql-shell package for CentOS
     yum:
       name: "{{ packages }}"
+      state: latest
     vars:
       packages:
       - percona-mysql-shell
@@ -279,7 +290,7 @@
   - name: install percona-mysql-shell package for Debian/Ubuntu
     apt:
       update_cache: yes
-      state: present
+      state: latest
       name: "{{ packages }}"
     vars:
       packages:
@@ -289,6 +300,7 @@
   - name: install percona-mysql-router package for CentOS
     yum:
       name: "{{ packages }}"
+      state: latest
     vars:
       packages:
       - percona-mysql-router
@@ -297,7 +309,7 @@
   - name: install percona-mysql-router package for Debian/Ubuntu
     apt:
       update_cache: yes
-      state: present
+      state: latest
       name: "{{ packages }}"
     vars:
       packages:


### PR DESCRIPTION
In scope of https://jira.percona.com/browse/DISTMYSQL-198 the percona-orchestrator rpm packages were updated as follows:

instead of 1 package (percona-orchestrator) now 3 packages are installed :
percona-orchestrator
percona-orchestrator-cli
percona-orchestrator-client
Now the 'percona-orchestrator-client' on rpm packages is now located in /usr/bin/orchestrator-client instead of /usr/local/orchestrator/resources/bin/orchestrator-client (the same as in upstream).

In addition mysql-router and  mysql-shell upgrade test failed without `state: latest`.