### PR TITLE
Remove Debian Stretch from Binary Tarball Job

### DIFF
--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -119,7 +119,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/kaushikpuneet07/package-testing.git --branch remove-stretch --depth 1
+    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true

--- a/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
+++ b/binary-tarball-tests/ps/test-ps-binary-tarball.groovy
@@ -69,20 +69,6 @@ pipeline {
             junit 'package-testing/binary-tarball-tests/ps/report.xml'
           } //End steps
         } //End stage Debian Buster
-        stage('Debian Stretch') {
-          agent {
-            label "min-stretch-x64"
-          }
-          steps {
-            script {
-                currentBuild.displayName = "#${BUILD_NUMBER}-${PS_VERSION}-${PS_REVISION}"
-              }
-            withCredentials([usernamePassword(credentialsId: 'JenkinsAPI', passwordVariable: 'JENKINS_API_PWD', usernameVariable: 'JENKINS_API_USER')]) {
-              run_test()
-            }
-            junit 'package-testing/binary-tarball-tests/ps/report.xml'
-          } //End steps
-        } //End stage Debian Stretch
         stage('Centos7') {
           agent {
             label "min-centos-7-x64"
@@ -133,7 +119,7 @@ void run_test() {
     else
       sudo apt install -y git wget lsb-release
     fi
-    git clone https://github.com/Percona-QA/package-testing.git --branch master --depth 1
+    git clone https://github.com/kaushikpuneet07/package-testing.git --branch remove-stretch --depth 1
     cd package-testing/binary-tarball-tests/ps
     wget -q ${TARBALL_LINK}${TARBALL_NAME}
     ./run.sh || true


### PR DESCRIPTION
Remove Debian Stretch from Binary Tarball Job as it is no longer supported 