### PR TITLE
PS 8347 client check and ps 80 ansible playbook and script modifications

### DIFF
--- a/client_check.sh
+++ b/client_check.sh
@@ -41,7 +41,7 @@ log="/tmp/${product}_client_check.log"
 echo -n > "${log}"
 
 if [ -f /etc/redhat-release ] || [ -f /etc/system-release ]; then
-	if [ "${product}" = "ps56" ] || [ "${product}" = "ps57" ]; then
+  if [ "${product}" = "ps56" ] || [ "${product}" = "ps57" ]; then
     yum install -y Percona-Server-client${rpm_version}
   elif ([ -z ${install_mysql_shell} ] && [ "${product}" = "ps80" ]) || [ "${product}" = "ps80" -a "${install_mysql_shell}" = "yes" ]; then
     yum install -y percona-server-client percona-mysql-router percona-mysql-shell

--- a/client_check.sh
+++ b/client_check.sh
@@ -41,10 +41,12 @@ log="/tmp/${product}_client_check.log"
 echo -n > "${log}"
 
 if [ -f /etc/redhat-release ] || [ -f /etc/system-release ]; then
-  if [ "${product}" = "ps56" ] || [ "${product}" = "ps57" ]; then
+	if [ "${product}" = "ps56" ] || [ "${product}" = "ps57" ]; then
     yum install -y Percona-Server-client${rpm_version}
-  elif [ "${product}" = "ps80" ]; then
+  elif ([ -z ${install_mysql_shell} ] && [ "${product}" = "ps80" ]) || [ "${product}" = "ps80" -a "${install_mysql_shell}" = "yes" ]; then
     yum install -y percona-server-client percona-mysql-router percona-mysql-shell
+  elif [ "${product}" = "ps80" ] && [ "${install_mysql_shell}" = "no" ]; then
+    yum install -y percona-server-client percona-mysql-router
   elif [ "${product}" = "pxc56" ] || [ "${product}" = "pxc57" ]; then
     yum install -y Percona-XtraDB-Cluster-client${rpm_version}
   elif [ "${product}" = "pxc80" ]; then

--- a/playbooks/client_test.yml
+++ b/playbooks/client_test.yml
@@ -7,7 +7,9 @@
   become_method: sudo
   vars:
     client: "{{ lookup('env', 'client_to_test') }}"
-
+    install_mysql_shell: "{{ lookup('env', 'install_mysql_shell') }}"
+  environment:
+    install_mysql_shell: '{{ install_mysql_shell }}'
   tasks:
   - name: include tasks for test env setup
     import_tasks: ../tasks/test_prep.yml

--- a/playbooks/ps_80.yml
+++ b/playbooks/ps_80.yml
@@ -10,7 +10,10 @@
 - hosts: all
   become: true
   become_method: sudo
-
+  vars:
+    install_mysql_shell: "{{ lookup('env', 'install_mysql_shell') }}"
+  environment:
+    install_mysql_shell: '{{ install_mysql_shell }}'
   tasks:
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
@@ -100,13 +103,25 @@
 
   - name: install percona-mysql-shell package
     include_tasks: ../tasks/install_pshell.yml
+    when: (lookup('env', 'install_mysql_shell') == "yes") 
 
-  - name: check that Percona Server version is correct
-    shell: /package-testing/version_check.sh ps80 &> version-check.log
+  - name: Handle check that Percona Server version is correct
+    block: 
+      - name: Run the version_check.sh script
+        shell: /package-testing/version_check.sh ps80 &> version-check.log
 
-  - name: Log check for warnings in the previous stage
-    command: /package-testing/scripts/log-warning-check.sh version-check.log
-    when: (lookup('env', 'check_warnings') == "yes")
+      - name: Log check for warnings in the previous stage
+        command: /package-testing/scripts/log-warning-check.sh version-check.log
+        when: (lookup('env', 'check_warnings') == "yes")
+
+    rescue:
+      - name: Print the output of the version_check.sh logfile on the script failure
+        command: cat "version-check.log"
+        register: versioncheckoutput
+        
+      - name:   
+        ansible.builtin.fail:
+          msg: Failing the further tasks due to issues in the previous task.
 
   - name: check that Percona Server package versions are correct
     command: /package-testing/package_check.sh ps80

--- a/scripts/log-warning-check.sh
+++ b/scripts/log-warning-check.sh
@@ -3,9 +3,9 @@
 logfile=$1
 
 if [ "$(egrep -c "WARNING" ${logfile})" != 0 ];then
-        echo "WARNING: Warnings or Errors found in the installation logs:\n"
-        egrep "WARNING" ${logfile}
+        echo "!!! WARNING Detected !!!"
         exit 1
 else
         echo "Installation log is clean"
 fi
+

--- a/version_check.sh
+++ b/version_check.sh
@@ -108,13 +108,19 @@ if [ "${product}" = "ps56" -o "${product}" = "ps57" -o "${product}" = "ps80" ]; 
     exit 1
   fi
 
-  if [ ${product} = "ps80" ]; then
-    if [ "$(mysqlsh --version | grep -c ${version})" = 1 ]; then
-      echo "mysql-shell version is correct" >> "${log}"
-    else
-      echo "ERROR: mysql-shell version is incorrect"
-      exit 1
+  if [ -z ${install_mysql_shell} ] || [ ${install_mysql_shell} = "yes" ] ; then
+    if [ ${product} = "ps80" ]; then
+      if [ "$(mysqlsh --version | grep -c ${version})" = 1 ]; then
+        echo "mysql-shell version is correct" >> "${log}"
+      else
+        echo "ERROR: mysql-shell version is incorrect"
+        exit 1
+      fi
     fi
+  elif [ ${install_mysql_shell} = "no" ]; then
+    echo "MYSQL Shell check is disabled.." >> "${log}"
+  else 
+    echo "Invalid input in ${install_mysql_shell} variable" 
   fi
 
 elif [ ${product} = "pxc56" -o ${product} = "pxc57" -o ${product} = "pxc80" ]; then

--- a/version_check.sh
+++ b/version_check.sh
@@ -108,19 +108,19 @@ if [ "${product}" = "ps56" -o "${product}" = "ps57" -o "${product}" = "ps80" ]; 
     exit 1
   fi
 
-  if [ -z ${install_mysql_shell} ] || [ ${install_mysql_shell} = "yes" ] ; then
-    if [ ${product} = "ps80" ]; then
+  if [ ${product} = "ps80" ]; then
+    if [ -z ${install_mysql_shell} ] || [ ${install_mysql_shell} = "yes" ] ; then
       if [ "$(mysqlsh --version | grep -c ${version})" = 1 ]; then
         echo "mysql-shell version is correct" >> "${log}"
       else
         echo "ERROR: mysql-shell version is incorrect"
         exit 1
       fi
+    elif [ ${install_mysql_shell} = "no" ]; then
+      echo "MYSQL Shell check is disabled.." >> "${log}"
+    else
+      echo "Invalid input in ${install_mysql_shell} variable"
     fi
-  elif [ ${install_mysql_shell} = "no" ]; then
-    echo "MYSQL Shell check is disabled.." >> "${log}"
-  else 
-    echo "Invalid input in ${install_mysql_shell} variable" 
   fi
 
 elif [ ${product} = "pxc56" -o ${product} = "pxc57" -o ${product} = "pxc80" ]; then


### PR DESCRIPTION
1) mysql shell installation option and backwards compatibility for version-check.sh script.
2) mysql shell installation option and backwards compatibility for client_check.sh script.
3) Modify the log_warning_check.sh for simple check output.
4) Modify the ansible playbook ps_80.yml to add var and env for mysql shell installation, 
5) Modify the ansible playbook ps_80.yml to add block and rescue for displaying output and stop the plays on warnings check failure.
5) Modify the ansible playbook client_test.yml to add var and env for mysql shell installation