### PR TITLE
PS 8347 client check and ps_80.yml modifications 

### DIFF
--- a/client_check.sh
+++ b/client_check.sh
@@ -76,18 +76,18 @@ fi
 if [ "${product}" = "ps80" ]; then
   echo "checking client version"
   if [ "$(mysql --version | grep -c "$version")" == 1 ]; then
-     echo "mysql client version is correct"
-   else
-     echo "ERROR: mysql-client version is incorrect "
-     exit 1
+    echo "mysql client version is correct"
+  else
+    echo "ERROR: mysql-client version is incorrect "
+    exit 1
   fi
   if [ -z ${install_mysql_shell} ] || [ ${install_mysql_shell} = "yes" ] ; then
     echo "checking shell version"
     if [ "$(mysqlsh --version | grep -c "$version")" == 1 ]; then
-        echo "mysql shell version is correct"
+      echo "mysql shell version is correct"
     else
-        echo "ERROR: mysql-shell version is incorrect "
-        exit 1
+      echo "ERROR: mysql-shell version is incorrect "
+      exit 1
     fi
   elif [ ${install_mysql_shell} = "no" ]; then
     echo "MYSQL Shell check is disabled.." >> "${log}"
@@ -97,10 +97,10 @@ if [ "${product}" = "ps80" ]; then
 
   echo "checking router version"
   if [ "$(mysqlrouter --version | grep -c "$version")" == 1 ]; then
-     echo "mysql router version is correct"
+    echo "mysql router version is correct"
   else
-     echo "ERROR: mysqlrouter version is incorrect "
-     exit 1
+    echo "ERROR: mysqlrouter version is incorrect "
+    exit 1
   fi
 fi
 

--- a/client_check.sh
+++ b/client_check.sh
@@ -37,6 +37,7 @@ else
 fi
 
 product=$1
+
 log="/tmp/${product}_client_check.log"
 echo -n > "${log}"
 
@@ -56,10 +57,12 @@ if [ -f /etc/redhat-release ] || [ -f /etc/system-release ]; then
     exit 1
   fi
 else
- if [ "${product}" = "ps56" ] || [ "${product}" = "ps57" ]; then
+  if [ "${product}" = "ps56" ] || [ "${product}" = "ps57" ]; then
     apt-get update; apt-get install -y percona-server-client${deb_version}
-  elif [ "${product}" = "ps80" ]; then
+  elif ([ -z ${install_mysql_shell} ] && [ "${product}" = "ps80" ]) || [ "${product}" = "ps80" -a "${install_mysql_shell}" = "yes" ]; then
     apt-get update; apt-get install -y percona-server-client percona-mysql-router percona-mysql-shell
+  elif [ "${product}" = "ps80" ] && [ "${install_mysql_shell}" = "no" ]; then
+    apt-get update; apt-get install -y percona-server-client percona-mysql-router
   elif [ "${product}" = "pxc56" ] || [ "${product}" = "pxc57" ]; then
     apt-get install -y percona-xtradb-cluster-client${deb_version}
   elif [ "${product}" = "pxc80" ]; then
@@ -71,27 +74,34 @@ else
 fi
 
 if [ "${product}" = "ps80" ]; then
- echo "checking client version"
- if [ "$(mysql --version | grep -c "$version")" == 1 ]; then
+  echo "checking client version"
+  if [ "$(mysql --version | grep -c "$version")" == 1 ]; then
      echo "mysql client version is correct"
    else
      echo "ERROR: mysql-client version is incorrect "
      exit 1
- fi
- echo "checking shell version"
- if [ "$(mysqlsh --version | grep -c "$version")" == 1 ]; then
-     echo "mysql shell version is correct"
-   else
-     echo "ERROR: mysql-shell version is incorrect "
-     exit 1
- fi
- echo "checking router version"
- if [ "$(mysqlrouter --version | grep -c "$version")" == 1 ]; then
+  fi
+  if [ -z ${install_mysql_shell} ] || [ ${install_mysql_shell} = "yes" ] ; then
+    echo "checking shell version"
+    if [ "$(mysqlsh --version | grep -c "$version")" == 1 ]; then
+        echo "mysql shell version is correct"
+    else
+        echo "ERROR: mysql-shell version is incorrect "
+        exit 1
+    fi
+  elif [ ${install_mysql_shell} = "no" ]; then
+    echo "MYSQL Shell check is disabled.." >> "${log}"
+  else
+    echo "Invalid input in ${install_mysql_shell} variable"
+  fi
+
+  echo "checking router version"
+  if [ "$(mysqlrouter --version | grep -c "$version")" == 1 ]; then
      echo "mysql router version is correct"
-   else
+  else
      echo "ERROR: mysqlrouter version is incorrect "
      exit 1
- fi
+  fi
 fi
 
 mysql --help

--- a/playbooks/client_test.yml
+++ b/playbooks/client_test.yml
@@ -47,10 +47,22 @@
       packages:
       - pv
     when: ansible_os_family == "RedHat"
-  
-  - name: install PS/PXC client and run the check
-    shell: /package-testing/client_check.sh {{ client }} &> client-check.log
 
-  - name: Log check for warnings in the previos stage
-    command: /package-testing/scripts/log-warning-check.sh client-check.log
-    when: (lookup('env', 'check_warnings') == "yes")
+  - name: Handle installation and checks for percona client using client_check.sh
+    block:
+      - name: install PS/PXC client and run the check
+        shell: /package-testing/client_check.sh {{ client }} > client-check.log 2>&1
+
+      - name: Log check for warnings in the previous stage
+        command: /package-testing/scripts/log-warning-check.sh client-check.log
+        when: (lookup('env', 'check_warnings') == "yes")
+
+    rescue:
+      - name: Fetch the output of the client_check.sh logfile on the script failure
+        command: cat "client-check.log"
+        register: clientcheckoutput
+
+      - name: Display the fetched output of the client-check.log logfile
+        debug:
+          msg: "Version check output: {{ clientcheckoutput.stdout }}"
+

--- a/playbooks/ps_80.yml
+++ b/playbooks/ps_80.yml
@@ -108,7 +108,7 @@
   - name: Handle check that Percona Server version is correct
     block: 
       - name: Run the version_check.sh script
-        shell: /package-testing/version_check.sh ps80 &> version-check.log
+        shell: /package-testing/version_check.sh ps80 > version-check.log 2>&1
 
       - name: Log check for warnings in the previous stage
         command: /package-testing/scripts/log-warning-check.sh version-check.log


### PR DESCRIPTION
1) Add install_mysql_shell conditional for Debian in client_check.sh for ps80

2) Add install_mysql_shell trigger for checking the version of mysql shell for ps80

3) Add structure similar to ps_80.yml for client_test.yml for conditional stdout/stderr display on the jenkins console during warnings detection.

4) Modify the "**install PS/PXC client and run the check**" task block in client_test.yml for classic and portable stdout/stderr forwarding. (Fixes stdout and sterr forwarding issues using ansible to client-check.log file in Debian)

5) Modify the "**Run the version_check.sh script**" task block in ps_80.yml for classic and portable stdout/stderr forwarding. (Fixes stdout and sterr forwarding issues using ansible to version-check.log file in Debian)