### PR TITLE
Add error about empty ERROR_LOG variable in plugins_test scripts

### DIFF
--- a/plugins_test_56.sh
+++ b/plugins_test_56.sh
@@ -3,9 +3,13 @@ set -e
 WARNINGS_BEFORE=0
 WARNINGS_AFTER=0
 ERROR_LOG=""
-ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$")
+ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$") || true
+if [ -z ${ERROR_LOG} ]; then
+  echo "ERROR_LOG variable is empty!"
+  exit 1
+fi
 if [ ! -f ${ERROR_LOG} ]; then
-  echo "Error log was not found!"
+  echo "Error log file was not found!"
   exit 1
 fi
 WARNINGS_BEFORE=$(grep -c "\[Warning\]" ${ERROR_LOG} || true)

--- a/plugins_test_57.sh
+++ b/plugins_test_57.sh
@@ -3,9 +3,13 @@ set -e
 WARNINGS_BEFORE=0
 WARNINGS_AFTER=0
 ERROR_LOG=""
-ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$")
+ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$") || true
+if [ -z ${ERROR_LOG} ]; then
+  echo "ERROR_LOG variable is empty!"
+  exit 1
+fi
 if [ ! -f ${ERROR_LOG} ]; then
-  echo "Error log was not found!"
+  echo "Error log file was not found!"
   exit 1
 fi
 

--- a/plugins_test_57u.sh
+++ b/plugins_test_57u.sh
@@ -3,9 +3,13 @@ set -e
 WARNINGS_BEFORE=0
 WARNINGS_AFTER=0
 ERROR_LOG=""
-ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$")
+ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$") || true
+if [ -z ${ERROR_LOG} ]; then
+  echo "ERROR_LOG variable is empty!"
+  exit 1
+fi
 if [ ! -f ${ERROR_LOG} ]; then
-  echo "Error log was not found!"
+  echo "Error log file was not found!"
   exit 1
 fi
 WARNINGS_BEFORE=$(grep -c "\[Warning\]" ${ERROR_LOG} || true)

--- a/plugins_test_80.sh
+++ b/plugins_test_80.sh
@@ -3,9 +3,13 @@ set -e
 WARNINGS_BEFORE=0
 WARNINGS_AFTER=0
 ERROR_LOG=""
-ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$")
+ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$") || true
+if [ -z ${ERROR_LOG} ]; then
+  echo "ERROR_LOG variable is empty!"
+  exit 1
+fi
 if [ ! -f ${ERROR_LOG} ]; then
-  echo "Error log was not found!"
+  echo "Error log file was not found!"
   exit 1
 fi
 


### PR DESCRIPTION
If the ERROR_LOG variable was empty - the script failed on : `ERROR_LOG=$(mysql -N -s -e "show variables like 'log_error';" | grep -v "Warning:" | grep -o "\/.*$")` execution and no error was output. To fix this `|| true` part and corresponding checks were added.