### PR TITLE
DISTMYSQL-213: use major and minor versions for pdps and pdpxc tests

### DIFF
--- a/molecule/pdmysql/pdps/tasks/main.yml
+++ b/molecule/pdmysql/pdps/tasks/main.yml
@@ -20,11 +20,22 @@
     command: yum module disable mariadb -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8"
 
-  - name: enable the PDMYSQL-80 repo
+  - set_fact:
+      major_repo: "{{ lookup('env', 'MAJOR_REPO') }}"
+
+  - name: enable the pdps-{{ version }} repo
     command: percona-release enable-only pdps-{{ version }} {{ repo }}
     vars:
       repo: "{{ lookup('env', 'REPO') }}"
       version: "{{ lookup('env', 'VERSION') }}"
+    when: not major_repo
+
+  - name: enable the major pdps-{{ version }} repo
+    command: percona-release enable-only pdps-{{ version }} {{ repo }}
+    vars:
+      repo: "{{ lookup('env', 'REPO') }}"
+      version: "{{ lookup('env', 'VERSION').split('.')[0] + '.' + lookup('env', 'VERSION').split('.')[1] }}"
+    when: major_repo
 
   - name: install Percona Toolkit
     include_tasks: ../../../tasks/install_pt.yml

--- a/molecule/pdmysql/pdps_setup/tasks/main.yml
+++ b/molecule/pdmysql/pdps_setup/tasks/main.yml
@@ -20,10 +20,20 @@
     command: yum module disable mariadb -y
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8"
 
-  - name: Setup the PDMYSQL repo
+  - set_fact:
+      major_repo: "{{ lookup('env', 'MAJOR_REPO') }}"
+
+  - name: Setup the PDMYSQL repo pdps-{{ version }}
     command: percona-release setup -y pdps-{{ version }}
     vars:
       version: "{{ lookup('env', 'VERSION') }}"
+    when: not major_repo
+
+  - name: Setup the PDMYSQL repo pdps-{{ version }}
+    command: percona-release setup -y pdps-{{ version }}
+    vars:
+      version: "{{ lookup('env', 'VERSION').split('.')[0] + '.' + lookup('env', 'VERSION').split('.')[1] }}"
+    when: major_repo
 
   - name: install Percona Toolkit new deb packages
     include_tasks: ../../../tasks/install_pt.yml

--- a/molecule/pdmysql/pdpxc/tasks/main.yml
+++ b/molecule/pdmysql/pdpxc/tasks/main.yml
@@ -7,11 +7,22 @@
 - name: Install percona release
   include: ../../tasks/install_percona_release.yml
 
-- name: enable the PDMYSQL-80 repo
+- set_fact:
+    major_repo: "{{ lookup('env', 'MAJOR_REPO') }}"
+
+- name: enable the PDMYSQL-80 repo pdpxc-{{ version }}
   command: percona-release enable-only pdpxc-{{ version }} {{ repo }}
   vars:
     repo: "{{ lookup('env', 'REPO') }}"
     version: "{{ lookup('env', 'VERSION') }}"
+  when: not major_repo
+
+- name: enable the PDMYSQL-80 repo pdpxc-{{ version }}
+  command: percona-release enable-only pdpxc-{{ version }} {{ repo }}
+  vars:
+    repo: "{{ lookup('env', 'REPO') }}"
+    version: "{{ lookup('env', 'VERSION').split('.')[0] + '.' + lookup('env', 'VERSION').split('.')[1] }}"
+  when: major_repo
 
 - name: clean and update yum cache
   shell: |
@@ -131,10 +142,12 @@
   with_items:
   - rm -rf /package-testing
   - rm -f master.zip
-  - wget --no-check-certificate -O master.zip https://github.com/Percona-QA/package-testing/archive/master.zip
+  - wget --no-check-certificate -O master.zip "https://github.com/Percona-QA/package-testing/archive/{{ branch }}.zip"
   - unzip master.zip
   - rm -f master.zip
-  - mv package-testing-master /package-testing
+  - mv "package-testing-{{ branch }}" /package-testing
+  vars:
+    branch: "{{ lookup('env', 'TESTING_BRANCH') }}"
 
 - name: install latest bats from github
   command: "{{ item }}"

--- a/molecule/pdmysql/pdpxc_setup/tasks/main.yml
+++ b/molecule/pdmysql/pdpxc_setup/tasks/main.yml
@@ -7,10 +7,20 @@
 - name: Install percona release
   include: ../../tasks/install_percona_release.yml
 
-- name: enable the PDMYSQL repo
+- set_fact:
+    major_repo: "{{ lookup('env', 'MAJOR_REPO') }}"
+
+- name: enable the PDMYSQL repo pdpxc-{{ version }}
   command: percona-release setup -y pdpxc-{{ version }}
   vars:
     version: "{{ lookup('env', 'VERSION') }}"
+  when: not major_repo
+
+- name: enable the PDMYSQL repo pdpxc-{{ version }}
+  command: percona-release setup -y pdpxc-{{ version }}
+  vars:
+    version: "{{ lookup('env', 'VERSION').split('.')[0] + '.' + lookup('env', 'VERSION').split('.')[1] }}"
+  when: major_repo
 
 - name: clean and update yum cache
   shell: |
@@ -130,10 +140,12 @@
   with_items:
   - rm -rf /package-testing
   - rm -f master.zip
-  - wget --no-check-certificate -O master.zip https://github.com/Percona-QA/package-testing/archive/master.zip
+  - wget --no-check-certificate -O master.zip "https://github.com/Percona-QA/package-testing/archive/{{ branch }}.zip"
   - unzip master.zip
   - rm -f master.zip
-  - mv package-testing-master /package-testing
+  - mv "package-testing-{{ branch }}" /package-testing
+  vars:
+    branch: "{{ lookup('env', 'TESTING_BRANCH') }}"
 
 - name: install latest bats from github
   command: "{{ item }}"


### PR DESCRIPTION
MYSQL distribution packages are located in 2 repos: pd[pxc,ps]-8.0 and pd[pxc,ps]-8.0.xx (full version). The tests were extended to check packages versions in both repos:  pd[pxc,ps]-8.0 and pd[pxc,ps]-8.0.xx based on MAJOR_REPO variable value passed from the jenkins job.