### PR TITLE
PS-8363 Adding backwards compatibility for install_mysql_shell component

### DIFF
--- a/playbooks/ps_80.yml
+++ b/playbooks/ps_80.yml
@@ -11,9 +11,7 @@
   become: true
   become_method: sudo
   vars:
-    install_mysql_shell: "{{ lookup('env', 'install_mysql_shell') }}"
-  environment:
-    install_mysql_shell: '{{ install_mysql_shell }}'
+    install_mysql_shell: "{{ lookup('env', 'install_mysql_shell', default='') }}"
   tasks:
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
@@ -103,7 +101,7 @@
 
   - name: install percona-mysql-shell package
     include_tasks: ../tasks/install_pshell.yml
-    when: (lookup('env', 'install_mysql_shell') == "yes") 
+    when: install_mysql_shell == "yes" or install_mysql_shell == ""
 
   - name: Handle check that Percona Server version is correct
     block: 

--- a/playbooks/ps_80_major_upgrade_to.yml
+++ b/playbooks/ps_80_major_upgrade_to.yml
@@ -220,7 +220,7 @@
 
   - name: install percona-mysql-shell package
     include_tasks: ../tasks/install_pshell.yml
-    when: (lookup('env', 'install_mysql_shell') == "yes")
+    when: install_mysql_shell == "yes" or install_mysql_shell == ""
     
   - name: check that Percona XtraBackup version is correct
     command: /package-testing/version_check.sh pxb80

--- a/playbooks/ps_80_upgrade.yml
+++ b/playbooks/ps_80_upgrade.yml
@@ -94,7 +94,7 @@
 
   - name: install percona-mysql-shell package
     include_tasks: ../tasks/install_pshell.yml
-    when: (lookup('env', 'install_mysql_shell') == "yes")
+    when: install_mysql_shell == "yes" or install_mysql_shell == ""
     
   - name: install 3rd party packages with apt
     apt:
@@ -207,7 +207,7 @@
 
   - name: install percona-mysql-shell package
     include_tasks: ../tasks/install_pshell.yml
-    when: (lookup('env', 'install_mysql_shell') == "yes")
+    when: install_mysql_shell == "yes" or install_mysql_shell == ""
 
   - name: list installed packages
     include_tasks: ../tasks/list_installed_packages.yml


### PR DESCRIPTION
Added a default value for install_mysql_shell ansible var.

In case variable value is yes or if the variable value is not defined we set it to ' ' by default and then use it via when condition in ps_80.yml

Tested for the following cases :-

1. install_mysql_shell is not defined/set caused installation of mysql shell.
2. install_mysql_shell="yes"  caused installation of mysql shell.
3. install_mysql_shell="no" did not installed mysql shell and skipped the tasks.
