### PR TITLE
Update service module to command module to check proxysql status 

### DIFF
--- a/molecule/pdmysql/pdps-minor-upgrade/tasks/main.yml
+++ b/molecule/pdmysql/pdps-minor-upgrade/tasks/main.yml
@@ -83,13 +83,13 @@
     when: ansible_os_family == "RedHat"
 
   - name: start proxysql service
-    service: name=proxysql state=started
+    command: service proxysql start
 
   - name: stop proxysql service
-    service: name=proxysql state=stopped
+    command: service proxysql stop
 
   - name: start proxysql service
-    service: name=proxysql state=started
+    command: service proxysql start
 
   - name: install orchestrator new deb packages
     apt:

--- a/molecule/pdmysql/pdps/tasks/main.yml
+++ b/molecule/pdmysql/pdps/tasks/main.yml
@@ -99,13 +99,13 @@
     when: ansible_os_family == "RedHat"
 
   - name: start proxysql service
-    service: name=proxysql state=started
+    command: service proxysql start
 
   - name: stop proxysql service
-    service: name=proxysql state=stopped
+    command: service proxysql stop
 
   - name: start proxysql service
-    service: name=proxysql state=started
+    command: service proxysql start
 
   - name: install orchestrator new deb packages
     apt:

--- a/molecule/pdmysql/pdps_setup/tasks/main.yml
+++ b/molecule/pdmysql/pdps_setup/tasks/main.yml
@@ -98,13 +98,13 @@
     when: ansible_os_family == "RedHat"
 
   - name: start proxysql service
-    service: name=proxysql state=started
+    command: service proxysql start
 
   - name: stop proxysql service
-    service: name=proxysql state=stopped
+    command: service proxysql stop
 
   - name: start proxysql service
-    service: name=proxysql state=started
+    command: service proxysql start
 
   - name: install orchestrator new deb packages
     apt:


### PR DESCRIPTION
service module and systemd module are not working with oracle linux 9 distribution . So updating command module instead of service/systemd .