### PR TITLE
PXC 80 bats test issue, Increase sleep to 20s from 10s

### DIFF
--- a/bats/pxc-init-scripts.bats
+++ b/bats/pxc-init-scripts.bats
@@ -188,7 +188,7 @@ function teardown(){
   if [ ${SERVICE} -eq 1 ]; then
     service mysql restart 3>- &
     [ $? -eq 0 ]
-    sleep 10
+    sleep 20
     run is_running
     [ $status -eq 0 ]
   else


### PR DESCRIPTION
Resolves the bats test restart using service command issue.