### PR TITLE
PS8.0.32: disable SElinux for kmip tests

### DIFF
--- a/playbooks/ps_80_kmip.yml
+++ b/playbooks/ps_80_kmip.yml
@@ -11,6 +11,10 @@
   - name: include tasks for test env setup
     include_tasks: ../tasks/test_prep.yml
 
+  - name: disable selinux
+    selinux: state=disabled
+    when: ansible_os_family == "RedHat"
+
   - name: include tasks for enabling PS 8 test repo
     include: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"


### PR DESCRIPTION
KMPI tests were failing for RHEL distros. For tests the client certificate was located in custom folder:
package-testing/kmip/client_certificate_john_smith.pem. On RHEL machines where the selinux was set to 'enforcing', the access to cert was blocked by SElinux, server did not get key for de-encryption and failed to start.