### PR TITLE
Add molecule aws instance-tags for instance/job identification for PXC Package testing job

### DIFF
--- a/molecule/pxc/pxc57-bootstrap-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-centos-7-install
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-10-install
     region: us-west-2
     image: ami-013e2c587714af230
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-11-install
     region: us-west-2
     image: ami-0d0f7602aa5c2425d
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-min-amazon-2-install
     region: us-west-2
     image: ami-0f9f005c313373218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-8-install
     region: us-west-2
     image: ami-000b99c02c2b64925
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-9-install
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-bionic-install
     region: us-west-2
     image: ami-074251216af698218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-focal-install
     region: us-west-2
     image: ami-0892d3c7ee96c0bf7
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-jammy-install
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-centos-7-upgrade
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-10-upgrade
     region: us-west-2
     image: ami-013e2c587714af230
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-11-upgrade
     region: us-west-2
     image: ami-0d0f7602aa5c2425d
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-min-amazon-2-upgrade
     region: us-west-2
     image: ami-0f9f005c313373218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-8-upgrade
     region: us-west-2
     image: ami-000b99c02c2b64925
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-9-upgrade
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-bionic-upgrade
     region: us-west-2
     image: ami-074251216af698218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-focal-upgrade
     region: us-west-2
     image: ami-0892d3c7ee96c0bf7
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-jammy-upgrade
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc57
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-centos-7-install
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-10-install
     region: us-west-2
     image: ami-013e2c587714af230
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-11-install
     region: us-west-2
     image: ami-0d0f7602aa5c2425d
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-min-amazon-2-install
     region: us-west-2
     image: ami-0f9f005c313373218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-8-install
     region: us-west-2
     image: ami-000b99c02c2b64925
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-9-install
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-bionic-install
     region: us-west-2
     image: ami-074251216af698218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-focal-install
     region: us-west-2
     image: ami-00712dae9a53f8c15
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-jammy-install
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/centos-7/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-centos-7-upgrade
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/debian-10/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-10-upgrade
     region: us-west-2
     image: ami-013e2c587714af230
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/debian-11/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-11-upgrade
     region: us-west-2
     image: ami-0d0f7602aa5c2425d
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/min-amazon-2/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-min-amazon-2-upgrade
     region: us-west-2
     image: ami-0f9f005c313373218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ol-8/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-8-upgrade
     region: us-west-2
     image: ami-000b99c02c2b64925
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ol-9/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-9-upgrade
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-bionic-upgrade
     region: us-west-2
     image: ami-074251216af698218
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-focal-upgrade
     region: us-west-2
     image: ami-00712dae9a53f8c15
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -15,6 +15,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-jammy-upgrade
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
@@ -24,6 +25,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pxc-worker
+      job-name: pxc-package-testing-job-pxc80
 provisioner:
   name: ansible
   playbooks:


### PR DESCRIPTION
This change is for PXC package testing job.
We add a instance-tag in molecule to identify an instance with the pxc package testing jenkins job.

-pxc-57 and -pxc-80 is for component level identification.