### PR TITLE
Add job-name under instance-tags in aws molecule for PS Innodb Testing

### DIFF
--- a/molecule/ps-innodb-cluster/server/molecule/centos-7/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/centos-7/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-centos-7
     region: us-west-2
     image: ami-036d2cdf95d86d256
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-centos-7
     region: us-west-2
     image: ami-036d2cdf95d86d256
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/debian-10/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/debian-10/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-debian-10
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
@@ -26,6 +27,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-debian-10
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
@@ -35,6 +37,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/debian-11/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/debian-11/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-debian-11
     region: us-west-2
     image: ami-05f9dcaa9ddb9a15e
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-debian-11
     region: us-west-2
     image: ami-05f9dcaa9ddb9a15e
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/debian-9/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/debian-9/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-debian-9
     region: us-west-2
     image: ami-01d07e14f082b3ba1
@@ -26,6 +27,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-debian-9
     region: us-west-2
     image: ami-01d07e14f082b3ba1
@@ -35,6 +37,7 @@ platforms:
     root_device_name: xvda
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/oracle-8/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/oracle-8/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-oracle-8
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-oracle-8
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/oracle-9/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-oracle-9
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-oracle-9
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/ubuntu-bionic/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-ubuntu-bionic
     region: us-west-2
     image: ami-06ffade19910cbfc0
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-ubuntu-bionic
     region: us-west-2
     image: ami-06ffade19910cbfc0
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/ubuntu-focal/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-ubuntu-focal
     region: us-west-2
     image: ami-09dd2e08d601bff67
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-ubuntu-focal
     region: us-west-2
     image: ami-09dd2e08d601bff67
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:

--- a/molecule/ps-innodb-cluster/server/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/ubuntu-jammy/molecule.yml
@@ -17,6 +17,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node2-ubuntu-jammy
     region: us-west-2
     image: ami-00b0c1efb144c2176
@@ -26,6 +27,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
   - name: ps-node3-ubuntu-jammy
     region: us-west-2
     image: ami-00b0c1efb144c2176
@@ -35,6 +37,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-ps-worker
+      job-name: test-ps-innodb-cluster
 provisioner:
   name: ansible
   lint:


### PR DESCRIPTION
Add Molecule instance-tags for ps innodb testing job identification on aws console.