### PR TITLE
Add job-name under instance-tags in aws molecule for PDPS Orchestrator

### DIFF
--- a/molecule/pdmysql/orchestrator/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pdmysql/orchestrator/molecule/ubuntu-bionic/molecule.yml
@@ -13,6 +13,7 @@ platforms:
     root_device_name: /dev/sda1
     instance_tags:
       iit-billing-tag: jenkins-pg-worker
+      job-name: pdps-orchestrator
 provisioner:
   name: ansible
   log: True


### PR DESCRIPTION
Addition of job-name under instance-tags in aws molecule for PDPS Orchestrator test job