### PR TITLE
Move PXC package testing job to PXC Jenkins Server

### DIFF
--- a/molecule/pxc/pxc57-bootstrap-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-centos-7-install
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-debian-10-install
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-debian-11-install
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-min-amazon-2-install
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ol-8-install
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ol-9-install
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ubuntu-bionic-install
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ubuntu-focal-install
-    region: us-west-2
-    image: ami-0892d3c7ee96c0bf7
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ubuntu-jammy-install
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-centos-7-upgrade
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-debian-10-upgrade
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-debian-11-upgrade
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-min-amazon-2-upgrade
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ol-8-upgrade
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ol-9-upgrade
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ubuntu-bionic-upgrade
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ubuntu-focal-upgrade
-    region: us-west-2
-    image: ami-0892d3c7ee96c0bf7
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-57-bootstrap-ubuntu-jammy-upgrade
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-centos-7-install
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-centos-7-install
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-debian-10-install
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-10-install
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-common-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-debian-11-install
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-11-install
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-common-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-min-amazon-2-install
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-min-amazon-2-install
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-common-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ol-8-install
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-8-install
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ol-9-install
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-9-install
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ubuntu-bionic-install
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-bionic-install
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ubuntu-focal-install
-    region: us-west-2
-    image: ami-0892d3c7ee96c0bf7
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-focal-install
-    region: us-west-2
-    image: ami-0892d3c7ee96c0bf7
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-common-install/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ubuntu-jammy-install
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-jammy-install
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-centos-7-upgrade
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-centos-7-upgrade
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-debian-10-upgrade
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-10-upgrade
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-common-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-debian-11-upgrade
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-debian-11-upgrade
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-common-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-min-amazon-2-upgrade
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-min-amazon-2-upgrade
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ol-8-upgrade
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-8-upgrade
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ol-9-upgrade
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ol-9-upgrade
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ubuntu-bionic-upgrade
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-bionic-upgrade
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ubuntu-focal-upgrade
-    region: us-west-2
-    image: ami-0892d3c7ee96c0bf7
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-focal-upgrade
-    region: us-west-2
-    image: ami-0892d3c7ee96c0bf7
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc57-common-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-57-common-ubuntu-jammy-upgrade
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc57
   - name: pxc3-57-common-ubuntu-jammy-upgrade
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-centos-7-install
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-debian-10-install
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-debian-11-install
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-min-amazon-2-install
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ol-8-install
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ol-9-install
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ubuntu-bionic-install
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ubuntu-focal-install
-    region: us-west-2
-    image: ami-00712dae9a53f8c15
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ubuntu-jammy-install
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-centos-7-upgrade
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-debian-10-upgrade
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-debian-11-upgrade
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-min-amazon-2-upgrade
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ol-8-upgrade
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ol-9-upgrade
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ubuntu-bionic-upgrade
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ubuntu-focal-upgrade
-    region: us-west-2
-    image: ami-00712dae9a53f8c15
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc1-80-bootstrap-ubuntu-jammy-upgrade
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-install/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-centos-7-install
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-centos-7-install
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-install/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-debian-10-install
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-10-install
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-debian-11-install
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-11-install
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-min-amazon-2-install
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-min-amazon-2-install
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ol-8-install
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-8-install
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-install/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ol-9-install
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-9-install
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ubuntu-bionic-install
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-bionic-install
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ubuntu-focal-install
-    region: us-west-2
-    image: ami-00712dae9a53f8c15
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-focal-install
-    region: us-west-2
-    image: ami-00712dae9a53f8c15
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ubuntu-jammy-install
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-jammy-install
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/centos-7/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-centos-7-upgrade
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-centos-7-upgrade
-    region: us-west-2
-    image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0b3edaff7c5648c74
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/debian-10/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-debian-10-upgrade
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-10-upgrade
-    region: us-west-2
-    image: ami-013e2c587714af230
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-024fe42989cf9e876
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/debian-11/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-debian-11-upgrade
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-debian-11-upgrade
-    region: us-west-2
-    image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-09b4378b1d3387f81
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-upgrade/molecule/min-amazon-2/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/min-amazon-2/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-min-amazon-2-upgrade
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-min-amazon-2-upgrade
-    region: us-west-2
-    image: ami-0f9f005c313373218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-061352bb71c4724b2
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ol-8/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ol-8/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ol-8-upgrade
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-8-upgrade
-    region: us-west-2
-    image: ami-000b99c02c2b64925
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-06339041e422fab06
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ol-9/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ol-9/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ol-9-upgrade
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ol-9-upgrade
-    region: us-west-2
-    image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d1958c85fb6a7b3e
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ubuntu-bionic-upgrade
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-bionic-upgrade
-    region: us-west-2
-    image: ami-074251216af698218
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-009726b835c24a3aa
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-focal/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ubuntu-focal-upgrade
-    region: us-west-2
-    image: ami-00712dae9a53f8c15
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-focal-upgrade
-    region: us-west-2
-    image: ami-00712dae9a53f8c15
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0d221cb540e0015f4
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxc/pxc80-common-upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,9 +7,9 @@ driver:
   name: ec2
 platforms:
   - name: pxc2-80-common-ubuntu-jammy-upgrade
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -17,9 +17,9 @@ platforms:
       iit-billing-tag: jenkins-pxc-worker
       job-name: pxc-package-testing-job-pxc80
   - name: pxc3-80-common-ubuntu-jammy-upgrade
-    region: us-west-2
-    image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-0430e63d7cdbcd237
+    region: us-west-1
+    image: ami-0dc5e9ff792ec08e3
+    vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1


### PR DESCRIPTION
Created new VPC, Subnet, IGW, RT for molecule on pxc.cd jenkins server

Modify the AMI, VPC_SUBNET, REGION for debian-11 for pxc57,pxc80 install and upgrade

Modify the AMI, VPC_SUBNET, REGION for centos-7 for pxc57,pxc80 install and upgrade us-west-1 (Issues with AMI not being visible)

Modify the AMI, VPC_SUBNET, REGION for debian-10 for pxc57,pxc80 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for min-amazon-2 for pxc57,pxc80 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for ol-8 for pxc57,pxc80 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for ol-9 for pxc57,pxc80 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for ubuntu-bionic for pxc57,pxc80 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for ubuntu-focal for pxc57 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for ubuntu-focal for pxc57, pxc80 install and upgrade us-west-1

Modify the AMI, VPC_SUBNET, REGION for ubuntu-jammy for pxc57, pxc80 install and upgrade us-west-1