### PR TITLE
PMM-7 increased default wait

### DIFF
--- a/tasks/verify_pmm2_metric.yml
+++ b/tasks/verify_pmm2_metric.yml
@@ -64,8 +64,8 @@
           shell: "curl -s -H 'Authorization: Basic {{ '%s:%s' | format('pmm', agent_password) | b64encode }}' 'http://127.0.0.1:{{ exporter_port.stdout }}/metrics' | grep '{{ item.metric }}'"
           register: metric_with_auth
           until: metric_with_auth.stdout == item.metric
-          delay: "{{ delay | default(0, true) }}"
-          retries: "{{ retries | default(0, true) }}"
+          delay: "{{ delay | default(5, true) }}"
+          retries: "{{ retries | default(3, true) }}"
         - name: "{{ item.service_name }}: assert metric is received"
           debug:
             msg: "{{ item.service_name }}: metric received!"


### PR DESCRIPTION
Increased default waiting for metrics timeout to make tests more stable.