### PR TITLE
Ansible: replace include: with include_tasks:

### DIFF
--- a/molecule/pdmysql/haproxy/tasks/main.yml
+++ b/molecule/pdmysql/haproxy/tasks/main.yml
@@ -13,10 +13,10 @@
 # /usr/bin/clustercheck
 
 - name: include playbook for removing Percona repo
-  include: ../../../tasks/remove_percona_repository.yml
+  include_tasks: ../../../tasks/remove_percona_repository.yml
 
 - name: Install percona release
-  include: ../../tasks/install_percona_release.yml
+  include_tasks: ../../tasks/install_percona_release.yml
 
 - name: enable the PDMYSQL-80 repo
   command: percona-release enable-only pdpxc-{{ version }} {{ repo }}

--- a/molecule/pdmysql/orchestrator/tasks/main.yml
+++ b/molecule/pdmysql/orchestrator/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for pdps
   - name: include playbook for removing Percona repo
-    include: ../../../tasks/remove_percona_repository.yml
+    include_tasks: ../../../tasks/remove_percona_repository.yml
 
   - name: Install percona release
-    include: ../../tasks/install_percona_release.yml
+    include_tasks: ../../tasks/install_percona_release.yml
 
   - name: enable the PDMYSQL-{{ version }} {{ repo }}
     command: percona-release enable-only pdps-{{ version }} {{ repo }}

--- a/molecule/pdmysql/pdps/tasks/main.yml
+++ b/molecule/pdmysql/pdps/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for pdps
   - name: include playbook for removing Percona repo
-    include: ../../../tasks/remove_percona_repository.yml
+    include_tasks: ../../../tasks/remove_percona_repository.yml
 
   - name: Install percona release
-    include: ../../tasks/install_percona_release.yml
+    include_tasks: ../../tasks/install_percona_release.yml
 
   - name: clean and update yum cache
     shell: |

--- a/molecule/pdmysql/pdps_minor_upgrade/tasks/main.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for pdps
   - name: include playbook for removing Percona repo
-    include: ../../../tasks/remove_percona_repository.yml
+    include_tasks: ../../../tasks/remove_percona_repository.yml
 
   - name: Install percona release
-    include: ../../tasks/install_percona_release.yml
+    include_tasks: ../../tasks/install_percona_release.yml
 
   - name: clean and update yum cache
     shell: |

--- a/molecule/pdmysql/pdps_setup/tasks/main.yml
+++ b/molecule/pdmysql/pdps_setup/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # tasks file for pdps
   - name: include playbook for removing Percona repo
-    include: ../../../tasks/remove_percona_repository.yml
+    include_tasks: ../../../tasks/remove_percona_repository.yml
 
   - name: Install percona release
-    include: ../../tasks/install_percona_release.yml
+    include_tasks: ../../tasks/install_percona_release.yml
 
   - name: clean and update yum cache
     shell: |

--- a/molecule/pdmysql/pdpxc/tasks/main.yml
+++ b/molecule/pdmysql/pdpxc/tasks/main.yml
@@ -2,10 +2,10 @@
 # tasks file for pdpxc
 
 - name: include playbook for removing Percona repo
-  include: ../../../tasks/remove_percona_repository.yml
+  include_tasks: ../../../tasks/remove_percona_repository.yml
 
 - name: Install percona release
-  include: ../../tasks/install_percona_release.yml
+  include_tasks: ../../tasks/install_percona_release.yml
 
 - set_fact:
     major_repo: "{{ lookup('env', 'MAJOR_REPO') }}"

--- a/molecule/pdmysql/pdpxc_minor_upgrade/tasks/main.yml
+++ b/molecule/pdmysql/pdpxc_minor_upgrade/tasks/main.yml
@@ -2,10 +2,10 @@
 # tasks file for pdpxc
 
 - name: include playbook for removing Percona repo
-  include: ../../../tasks/remove_percona_repository.yml
+  include_tasks: ../../../tasks/remove_percona_repository.yml
 
 - name: Install percona release
-  include: ../../tasks/install_percona_release.yml
+  include_tasks: ../../tasks/install_percona_release.yml
 
 - name: enable the old repository pdppxc-{{ pdmysql_version }} {{ repo }}
   command: percona-release enable-only pdpxc-{{ pdmysql_version }} {{ repo }}

--- a/molecule/pdmysql/pdpxc_setup/tasks/main.yml
+++ b/molecule/pdmysql/pdpxc_setup/tasks/main.yml
@@ -2,10 +2,10 @@
 # tasks file for pdpxc
 
 - name: include playbook for removing Percona repo
-  include: ../../../tasks/remove_percona_repository.yml
+  include_tasks: ../../../tasks/remove_percona_repository.yml
 
 - name: Install percona release
-  include: ../../tasks/install_percona_release.yml
+  include_tasks: ../../tasks/install_percona_release.yml
 
 - set_fact:
     major_repo: "{{ lookup('env', 'MAJOR_REPO') }}"

--- a/molecule/ps-56-install/tasks/main.yml
+++ b/molecule/ps-56-install/tasks/main.yml
@@ -12,15 +12,15 @@
     include_tasks: ../../../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
-    include: ../../../tasks/enable_testing_repo.yml
+    include_tasks: ../../../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../../../tasks/enable_main_repo.yml
+    include_tasks: ../../../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../../../tasks/enable_experimental_repo.yml
+    include_tasks: ../../../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/molecule/ps-57-install/tasks/main.yml
+++ b/molecule/ps-57-install/tasks/main.yml
@@ -20,15 +20,15 @@
               mode=0664 owner=root group=root
 
   - name: include tasks for enabling test repo
-    include: ../../../tasks/enable_testing_repo.yml
+    include_tasks: ../../../tasks/enable_testing_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "testing" or lookup('env', 'INSTALL_REPO') == ""
 
   - name: include tasks for enabling main repo
-    include: ../../../tasks/enable_main_repo.yml
+    include_tasks: ../../../tasks/enable_main_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../../../tasks/enable_experimental_repo.yml
+    include_tasks: ../../../tasks/enable_experimental_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "experimental"
 
   - name: download and extract world database

--- a/molecule/ps-57-maj-upgrade-from/tasks/main.yml
+++ b/molecule/ps-57-maj-upgrade-from/tasks/main.yml
@@ -70,15 +70,15 @@
     when: (ansible_distribution == "Amazon") or (ansible_os_family == "RedHat" and ansible_distribution_major_version >= "7")
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: enable tools testing repo

--- a/molecule/ps-57-maj-upgrade-to/tasks/main.yml
+++ b/molecule/ps-57-maj-upgrade-to/tasks/main.yml
@@ -80,15 +80,15 @@
               mode=0664 owner=root group=root
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: enable tools testing repo

--- a/molecule/ps-57-upgrade/tasks/main.yml
+++ b/molecule/ps-57-upgrade/tasks/main.yml
@@ -11,7 +11,7 @@
 # import_playbook: test_prep.yml
 
   - name: include tasks for test env setup
-    include: ../../../tasks/test_prep.yml
+    include_tasks: ../../../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../../../tasks/setup_local_vault.yml
@@ -20,7 +20,7 @@
 # Install from main repository
 #
   - name: include tasks for enabling main repo
-    include: ../../../tasks/enable_main_repo.yml
+    include_tasks: ../../../tasks/enable_main_repo.yml
 
   - name: setup config file for keyring vault
     template: src=../../../scripts/ps_keyring_plugins_test/keyring_vault_test_v2.j2
@@ -102,7 +102,7 @@
 #
 # Enable testing repository
 #
-  - include: ../../../tasks/enable_testing_repo.yml
+  - include_tasks: ../../../tasks/enable_testing_repo.yml
 
 #
 # Upgrade packages

--- a/molecule/ps-80-install/tasks/main.yml
+++ b/molecule/ps-80-install/tasks/main.yml
@@ -12,19 +12,19 @@
               mode=0664 owner=root group=root
 
   - name: include tasks for enabling main repo
-    include: ../../../tasks/enable_main_repo.yml
+    include_tasks: ../../../tasks/enable_main_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../../../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../../../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "testing" or lookup('env', 'INSTALL_REPO') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../../../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "experimental"
 
   - name: download and extract world database

--- a/molecule/ps-80-maj-upgrade-to/tasks/main.yml
+++ b/molecule/ps-80-maj-upgrade-to/tasks/main.yml
@@ -70,11 +70,11 @@
     when: (ansible_distribution == "Amazon") or (ansible_os_family == "RedHat" and ansible_distribution_major_version >= "7")
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../../../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../../../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: install Percona Server 8.0 packages

--- a/molecule/ps-80-upgrade/tasks/main.yml
+++ b/molecule/ps-80-upgrade/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # tasks file for ps-80-upgrade
   - name: include tasks for test env setup
-    include: ../../../tasks/test_prep.yml
+    include_tasks: ../../../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../../../tasks/setup_local_vault.yml
@@ -14,10 +14,10 @@
 # Install from main repository
 
   - name: include tasks for enabling main repo
-    include: ../../../tasks/enable_main_repo.yml
+    include_tasks: ../../../tasks/enable_main_repo.yml
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../../../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -93,7 +93,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS 8 testing repo
-    include: ../../../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../../../tasks/enable_ps8_testing_repo.yml
 
 #
 # Upgrade packages

--- a/molecule/ps-innodb-cluster/router/tasks/main.yml
+++ b/molecule/ps-innodb-cluster/router/tasks/main.yml
@@ -15,15 +15,15 @@
       var: PS_MAJ_VER  
 
   - name: include tasks for enabling PS 80/82 main repo
-    include: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_main_repo.yml
+    include_tasks: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_main_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "main"
 
   - name: include tasks for enabling PS 80/82 test repo
-    include: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_testing_repo.yml
+    include_tasks: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_testing_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "testing" or lookup('env', 'INSTALL_REPO') == ""
 
   - name: include tasks for enabling PS 80/82 experimental repo
-    include: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_experimental_repo.yml
+    include_tasks: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_experimental_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "experimental"
 
   - name: enable tools main repo

--- a/molecule/ps-innodb-cluster/server/tasks/main.yml
+++ b/molecule/ps-innodb-cluster/server/tasks/main.yml
@@ -15,15 +15,15 @@
       var: PS_MAJ_VER
     
   - name: include tasks for enabling PS 80/82 main repo
-    include: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_main_repo.yml
+    include_tasks: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_main_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "main"
 
   - name: include tasks for enabling PS 80/82 test repo
-    include: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_testing_repo.yml
+    include_tasks: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_testing_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "testing" or lookup('env', 'INSTALL_REPO') == ""
 
   - name: include tasks for enabling PS 80/82 experimental repo
-    include: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_experimental_repo.yml
+    include_tasks: ../../../../tasks/enable_ps{{ PS_MAJ_VER }}_experimental_repo.yml
     when: lookup('env', 'INSTALL_REPO') == "experimental"
 
   - name: setup hosts file

--- a/molecule/pxc-keyring-test/pxc-80-setup-pkgs/tasks/main.yml
+++ b/molecule/pxc-keyring-test/pxc-80-setup-pkgs/tasks/main.yml
@@ -18,7 +18,7 @@
     - "'pxc3' in inventory_hostname"
     
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/molecule/pxc/pxc57-bootstrap-install/tasks/main.yml
+++ b/molecule/pxc/pxc57-bootstrap-install/tasks/main.yml
@@ -20,7 +20,7 @@
   - debug: var=man_ip
     
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/molecule/pxc/pxc57-bootstrap-upgrade/tasks/main.yml
+++ b/molecule/pxc/pxc57-bootstrap-upgrade/tasks/main.yml
@@ -20,7 +20,7 @@
   - debug: var=man_ip
     
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/molecule/pxc/pxc57-common-install/tasks/main.yml
+++ b/molecule/pxc/pxc57-common-install/tasks/main.yml
@@ -20,7 +20,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
     include_tasks: ../../../../tasks/enable_pxc57_testing_repo.yml

--- a/molecule/pxc/pxc57-common-upgrade/tasks/main.yml
+++ b/molecule/pxc/pxc57-common-upgrade/tasks/main.yml
@@ -20,7 +20,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
     include_tasks: ../../../../tasks/enable_pxc57_testing_repo.yml

--- a/molecule/pxc/pxc80-bootstrap-install/tasks/main.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/tasks/main.yml
@@ -18,7 +18,7 @@
     - "'pxc3' in inventory_hostname"
 
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/molecule/pxc/pxc80-bootstrap-upgrade/tasks/main.yml
+++ b/molecule/pxc/pxc80-bootstrap-upgrade/tasks/main.yml
@@ -18,7 +18,7 @@
     - "'pxc3' in inventory_hostname"
 
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/molecule/pxc/pxc80-common-install/tasks/main.yml
+++ b/molecule/pxc/pxc80-common-install/tasks/main.yml
@@ -18,7 +18,7 @@
     - "'pxc3' in inventory_hostname"
 
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/molecule/pxc/pxc80-common-upgrade/tasks/main.yml
+++ b/molecule/pxc/pxc80-common-upgrade/tasks/main.yml
@@ -18,7 +18,7 @@
     - "'pxc3' in inventory_hostname"
 
   - name: include tasks for test env setup
-    include: ../../../../tasks/test_prep.yml
+    include_tasks: ../../../../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/playbooks/client_test.yml
+++ b/playbooks/client_test.yml
@@ -15,31 +15,31 @@
     import_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling main repo ps ps57
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: (lookup('env', 'install_repo') == "main") and (lookup('env', 'client_to_test') == "ps57")
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: (lookup('env', 'install_repo') == "main") and (lookup('env', 'client_to_test') == "ps80")
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: (lookup('env', 'install_repo') == "testing") and (lookup('env', 'client_to_test') == "ps80")
 
   - name: include tasks for enabling test repo ps ps57
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: (lookup('env', 'install_repo') == "testing") and (lookup('env', 'client_to_test') == "ps57")
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo 
-    include: ../tasks/enable_ps_innovation_repo_main.yml 
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml 
     when: (lookup('env', 'install_repo') == "main") and (lookup('env', 'client_to_test') == "innovation-lts")
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: (lookup('env', 'install_repo') == "testing") and (lookup('env', 'client_to_test') == "innovation-lts")
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: (lookup('env', 'install_repo') == "experimental") and (lookup('env', 'client_to_test') == "innovation-lts")
 
   - name: install deb packages

--- a/playbooks/client_test_upgrade.yml
+++ b/playbooks/client_test_upgrade.yml
@@ -13,15 +13,15 @@
     import_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling main repo ps ps57
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: (lookup('env', 'install_repo') == "main") and (lookup('env', 'client_to_test') == "ps57")
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: (lookup('env', 'install_repo') == "main") and (lookup('env', 'client_to_test') == "ps80")
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo 
-    include: ../tasks/enable_ps_innovation_repo_main.yml 
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml 
     when: (lookup('env', 'install_repo') == "main") and (lookup('env', 'client_to_test') == "innovation-lts")
 
   - name: install deb packages
@@ -73,15 +73,15 @@
       - (ansible_os_family == "Debian") and (lookup('env', 'client_to_test') == "innovation-lts")
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'client_to_test') == "ps80"
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'client_to_test') == "ps57"
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'client_to_test') == "innovation-lts"
 
   - name: install PS/PXC client and run the check

--- a/playbooks/common_56.yml
+++ b/playbooks/common_56.yml
@@ -16,19 +16,19 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: include tasks for enabling laboratory and main repos
-    include: ../tasks/enable_laboratory_with_main_repo.yml
+    include_tasks: ../tasks/enable_laboratory_with_main_repo.yml
     when: lookup('env', 'install_repo') == "laboratory"
 
   - name: download and extract world database

--- a/playbooks/common_56_upgrade.yml
+++ b/playbooks/common_56_upgrade.yml
@@ -15,13 +15,13 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
 #
 # Install from main repository
 #
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -144,10 +144,10 @@
 #
 # Enable testing repository or laboratory repository
 #
-  - include: ../tasks/enable_testing_repo.yml
+  - include_tasks: ../tasks/enable_testing_repo.yml
     when:  lookup('env', 'install_repo') != "laboratory"
 
-  - include: ../tasks/enable_laboratory_with_main_repo.yml
+  - include_tasks: ../tasks/enable_laboratory_with_main_repo.yml
     when:  lookup('env', 'install_repo') == "laboratory"
 
 #

--- a/playbooks/common_57.yml
+++ b/playbooks/common_57.yml
@@ -26,15 +26,15 @@
               mode=0664 owner=root group=root
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/common_57_major_upgrade_from.yml
+++ b/playbooks/common_57_major_upgrade_from.yml
@@ -32,15 +32,15 @@
               mode=0664 owner=root group=root
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database
@@ -208,15 +208,15 @@
     include_tasks: ../tasks/remove_pxb24.yml
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
 #

--- a/playbooks/common_57_major_upgrade_to.yml
+++ b/playbooks/common_57_major_upgrade_to.yml
@@ -22,15 +22,15 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database
@@ -290,15 +290,15 @@
     when: ansible_os_family == "RedHat" and ansible_distribution_major_version >= "8"
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: enable tools testing repo

--- a/playbooks/common_57_upgrade.yml
+++ b/playbooks/common_57_upgrade.yml
@@ -17,13 +17,13 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
 #
 # Install from main repository
 #
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../tasks/setup_local_vault.yml
@@ -118,7 +118,7 @@
 #
 # Enable testing repository
 #
-  - include: ../tasks/enable_testing_repo.yml
+  - include_tasks: ../tasks/enable_testing_repo.yml
 
 #
 # Upgrade packages

--- a/playbooks/pbm_upgrade.yml
+++ b/playbooks/pbm_upgrade.yml
@@ -42,7 +42,7 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling testing repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
 
   - name: upgrade Percona Toolkit to the latest deb packages
     apt: name={{item}} update_cache=yes state=latest

--- a/playbooks/ppg_11.yml
+++ b/playbooks/ppg_11.yml
@@ -16,24 +16,24 @@
     include_tasks: ../tasks/test_prep.yml
 
     #  - name: include tasks for enabling main repo
-    #include: ../tasks/enable_main_repo.yml
+    #include_tasks: ../tasks/enable_main_repo.yml
     #when: lookup('env', 'install_repo') == "main"
 
     #- name: include tasks for enabling PS 8 test repo
-    #include: ../tasks/enable_ps8_main_repo.yml
+    #include_tasks: ../tasks/enable_ps8_main_repo.yml
     #when: lookup('env', 'install_repo') == "main"
 
     #- name: include tasks for enabling PS 8 test repo
-    #include: ../tasks/enable_ps8_testing_repo.yml
+    #include_tasks: ../tasks/enable_ps8_testing_repo.yml
     #when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
     #- name: include tasks for enabling PS 8 experimental repo
-    #include: ../tasks/enable_ps8_experimental_repo.yml
+    #include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     #when: lookup('env', 'install_repo') == "experimental"
 
   ### temp part until percona-release is updated for PPG project
   - name: include tasks for enabling main repo (do this just for GPG key)
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: download newer percona-release script
     get_url:

--- a/playbooks/proxysql.yml
+++ b/playbooks/proxysql.yml
@@ -20,7 +20,7 @@
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: install proxysql new deb packages

--- a/playbooks/proxysql2.yml
+++ b/playbooks/proxysql2.yml
@@ -21,7 +21,7 @@
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: install proxysql new deb packages

--- a/playbooks/proxysql2_major_upgrade_to.yml
+++ b/playbooks/proxysql2_major_upgrade_to.yml
@@ -20,7 +20,7 @@
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: install proxysql new deb packages

--- a/playbooks/proxysql2_upgrade.yml
+++ b/playbooks/proxysql2_upgrade.yml
@@ -52,7 +52,7 @@
 #
 # Enable testing repository
 #
-  - include: ../tasks/enable_testing_repo.yml
+  - include_tasks: ../tasks/enable_testing_repo.yml
 
 #
 # Upgrade packages

--- a/playbooks/proxysql_upgrade.yml
+++ b/playbooks/proxysql_upgrade.yml
@@ -52,7 +52,7 @@
 #
 # Enable testing repository
 #
-  - include: ../tasks/enable_testing_repo.yml
+  - include_tasks: ../tasks/enable_testing_repo.yml
 
 #
 # Upgrade packages

--- a/playbooks/ps_80.yml
+++ b/playbooks/ps_80.yml
@@ -45,15 +45,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_80_kmip.yml
+++ b/playbooks/ps_80_kmip.yml
@@ -18,15 +18,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_80_kms.yml
+++ b/playbooks/ps_80_kms.yml
@@ -18,15 +18,15 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_80_major_upgrade_to.yml
+++ b/playbooks/ps_80_major_upgrade_to.yml
@@ -33,15 +33,15 @@
               mode=0664 owner=root group=root
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling experimental repo
-    include: ../tasks/enable_experimental_repo.yml
+    include_tasks: ../tasks/enable_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database
@@ -204,11 +204,11 @@
     include_tasks: ../tasks/remove_pxb24.yml
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: append include for RedHat

--- a/playbooks/ps_80_upgrade.yml
+++ b/playbooks/ps_80_upgrade.yml
@@ -20,7 +20,7 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../tasks/setup_local_vault.yml
@@ -33,10 +33,10 @@
 # Install from main repository
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -130,7 +130,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS 8 testing repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
 
 # Upgrade packages
 #

--- a/playbooks/ps_81.yml
+++ b/playbooks/ps_81.yml
@@ -45,15 +45,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_81_kmip.yml
+++ b/playbooks/ps_81_kmip.yml
@@ -18,15 +18,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_81_kms.yml
+++ b/playbooks/ps_81_kms.yml
@@ -18,15 +18,15 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_81_major_upgrade_to.yml
+++ b/playbooks/ps_81_major_upgrade_to.yml
@@ -20,7 +20,7 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../tasks/setup_local_vault.yml
@@ -33,10 +33,10 @@
 # Install from main repository
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: include tasks for enabling PS 8.0 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -117,11 +117,11 @@
 # Enable testing/main repository
 #
   - name: include tasks for enabling PS 8.1 testing repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
 

--- a/playbooks/ps_81_upgrade.yml
+++ b/playbooks/ps_81_upgrade.yml
@@ -20,7 +20,7 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../tasks/setup_local_vault.yml
@@ -33,7 +33,7 @@
 # Install from main repository
 
   - name: include tasks for enabling PS 8.1 main repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -112,7 +112,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS 8.1 testing repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
 
 # Upgrade packages
 #

--- a/playbooks/ps_lts_innovation.yml
+++ b/playbooks/ps_lts_innovation.yml
@@ -61,15 +61,15 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_lts_innovation_kmip.yml
+++ b/playbooks/ps_lts_innovation_kmip.yml
@@ -35,15 +35,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_lts_innovation_kms.yml
+++ b/playbooks/ps_lts_innovation_kms.yml
@@ -35,15 +35,15 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/ps_lts_innovation_major_upgrade_to.yml
+++ b/playbooks/ps_lts_innovation_major_upgrade_to.yml
@@ -20,7 +20,7 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../tasks/setup_local_vault.yml
@@ -49,10 +49,10 @@
 # Install from main repository
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: include tasks for enabling PS 8.0 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -141,11 +141,11 @@
 # Enable testing/main repository
 #
   - name: include tasks for enabling PS {{ major_release_version }} testing repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} testing repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
     
 # Upgrade packages

--- a/playbooks/ps_lts_innovation_upgrade.yml
+++ b/playbooks/ps_lts_innovation_upgrade.yml
@@ -36,7 +36,7 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
       
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for local vault setup
     include_tasks: ../tasks/setup_local_vault.yml
@@ -49,7 +49,7 @@
 # Install from main repository
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -128,7 +128,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS {{ major_release_version }} testing repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
 
 # Upgrade packages
 #

--- a/playbooks/pt_upgrade.yml
+++ b/playbooks/pt_upgrade.yml
@@ -46,4 +46,4 @@
     command: ../version_check.sh pt
 
   - name: remove pt packages
-    include: ../tasks/remove_pt.yml
+    include_tasks: ../tasks/remove_pt.yml

--- a/playbooks/pt_with_products.yml
+++ b/playbooks/pt_with_products.yml
@@ -91,4 +91,4 @@
     when: lookup('env', 'install_with') is match('(pxc|ps|upstream)(57|80)$')
 
   - name: remove pt packages
-    include: ../tasks/remove_pt.yml
+    include_tasks: ../tasks/remove_pt.yml

--- a/playbooks/pxb_23.yml
+++ b/playbooks/pxb_23.yml
@@ -15,11 +15,11 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: download and extract world database

--- a/playbooks/pxb_24.yml
+++ b/playbooks/pxb_24.yml
@@ -15,11 +15,11 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: download and extract world database

--- a/playbooks/pxb_24_tarball.yml
+++ b/playbooks/pxb_24_tarball.yml
@@ -32,11 +32,11 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: download and extract world database

--- a/playbooks/pxb_24_upgrade.yml
+++ b/playbooks/pxb_24_upgrade.yml
@@ -15,13 +15,13 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
 #
 # Install from main repository
 #
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -105,7 +105,7 @@
 #
 # Enable testing repository
 #
-  - include: ../tasks/enable_testing_repo.yml
+  - include_tasks: ../tasks/enable_testing_repo.yml
 
 #
 # Upgrade packages

--- a/playbooks/pxb_24_upstream.yml
+++ b/playbooks/pxb_24_upstream.yml
@@ -83,11 +83,11 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling tools test repo
-    include: ../tasks/enable_tools_testing_repo.yml
+    include_tasks: ../tasks/enable_tools_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling tools main repo
-    include: ../tasks/enable_tools_main_repo.yml
+    include_tasks: ../tasks/enable_tools_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: install Percona XtraBackup 2.4 packages

--- a/playbooks/pxb_80.yml
+++ b/playbooks/pxb_80.yml
@@ -16,19 +16,19 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_80_kmip.yml
+++ b/playbooks/pxb_80_kmip.yml
@@ -16,15 +16,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_80_tarball.yml
+++ b/playbooks/pxb_80_tarball.yml
@@ -35,19 +35,19 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8 test repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8 experimental repo
-    include: ../tasks/enable_ps8_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps8_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_80_upgrade.yml
+++ b/playbooks/pxb_80_upgrade.yml
@@ -16,15 +16,15 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
 # Install from testing repository
 
 #  - name: include tasks for enabling main repo
-#    include: ../tasks/enable_main_repo.yml
+#    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: include tasks for enabling PS 8 main repo
-    include: ../tasks/enable_ps8_main_repo.yml
+    include_tasks: ../tasks/enable_ps8_main_repo.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -85,7 +85,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS 8 testing repo
-    include: ../tasks/enable_ps8_testing_repo.yml
+    include_tasks: ../tasks/enable_ps8_testing_repo.yml
 
 #
 # Upgrade packages

--- a/playbooks/pxb_80_upstream.yml
+++ b/playbooks/pxb_80_upstream.yml
@@ -111,7 +111,7 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling tools test repo
-    include: ../tasks/enable_tools_testing_repo.yml
+    include_tasks: ../tasks/enable_tools_testing_repo.yml
 
   - name: install Percona XtraBackup 8.0 packages
     include_tasks: ../tasks/install_pxb80.yml

--- a/playbooks/pxb_81.yml
+++ b/playbooks/pxb_81.yml
@@ -16,19 +16,19 @@
     include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 main repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_81_kmip.yml
+++ b/playbooks/pxb_81_kmip.yml
@@ -16,15 +16,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_81_tarball.yml
+++ b/playbooks/pxb_81_tarball.yml
@@ -35,19 +35,19 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 main repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_81_upgrade.yml
+++ b/playbooks/pxb_81_upgrade.yml
@@ -16,23 +16,23 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
 # Install from testing repository
 
 #  - name: include tasks for enabling main repo
-#    include: ../tasks/enable_main_repo.yml
+#    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: include tasks for enabling PS 8.1 main repo
-    include: ../tasks/enable_ps81_main_repo.yml
+    include_tasks: ../tasks/enable_ps81_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS 8.1 test repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS 8.1 experimental repo
-    include: ../tasks/enable_ps81_experimental_repo.yml
+    include_tasks: ../tasks/enable_ps81_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database
@@ -94,7 +94,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS 8.1 testing repo
-    include: ../tasks/enable_ps81_testing_repo.yml
+    include_tasks: ../tasks/enable_ps81_testing_repo.yml
 
 #
 # Upgrade packages

--- a/playbooks/pxb_81_upstream.yml
+++ b/playbooks/pxb_81_upstream.yml
@@ -111,15 +111,15 @@
     when: ansible_os_family == "RedHat"
 
   - name: include tasks for enabling tools test repo
-    include: ../tasks/enable_tools_testing_repo.yml
+    include_tasks: ../tasks/enable_tools_testing_repo.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling tools experimental repo
-    include: ../tasks/enable_tools_experimental_repo.yml
+    include_tasks: ../tasks/enable_tools_experimental_repo.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: include tasks for enabling tools main repo
-    include: ../tasks/enable_tools_main_repo.yml
+    include_tasks: ../tasks/enable_tools_main_repo.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: install Percona XtraBackup 8.1 packages

--- a/playbooks/pxb_innovation_lts.yml
+++ b/playbooks/pxb_innovation_lts.yml
@@ -32,15 +32,15 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_kmip_innovation.yml
+++ b/playbooks/pxb_kmip_innovation.yml
@@ -32,15 +32,15 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_tarball_innovation_lts.yml
+++ b/playbooks/pxb_tarball_innovation_lts.yml
@@ -51,15 +51,15 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: download and extract world database

--- a/playbooks/pxb_upgrade_innovation_lts.yml
+++ b/playbooks/pxb_upgrade_innovation_lts.yml
@@ -16,12 +16,12 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
 # Install from testing repository
 
 #  - name: include tasks for enabling main repo
-#    include: ../tasks/enable_main_repo.yml
+#    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: Extract version number using shell commands
     shell: cat ../VERSIONS | grep -oP 'PS_INN_LTS_VER="\K(\d+)\.(\d+)' | tr -d '.'
@@ -40,7 +40,7 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
 
   - name: download and extract world database
     command: "{{ item }}"
@@ -102,7 +102,7 @@
 # Enable testing repository
 #
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
 #

--- a/playbooks/pxb_upstream_innovation_lts.yml
+++ b/playbooks/pxb_upstream_innovation_lts.yml
@@ -198,15 +198,15 @@
       ps_inn_lts_repo_name: "{{ ps_inn_lts_repo_name.stdout }}"
 
   - name: include tasks for enabling PS {{ major_release_version }} main repo
-    include: ../tasks/enable_ps_innovation_repo_main.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_main.yml
     when: lookup('env', 'install_repo') == "main"
 
   - name: include tasks for enabling PS {{ major_release_version }} test repo
-    include: ../tasks/enable_ps_innovation_repo_testing.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_testing.yml
     when: lookup('env', 'install_repo') == "testing" or lookup('env', 'install_repo') == ""
 
   - name: include tasks for enabling PS {{ major_release_version }} experimental repo
-    include: ../tasks/enable_ps_innovation_repo_experimental.yml
+    include_tasks: ../tasks/enable_ps_innovation_repo_experimental.yml
     when: lookup('env', 'install_repo') == "experimental"
 
   - name: install Percona XtraBackup {{ major_release_version }} packages

--- a/playbooks/pxc56_bootstrap.yml
+++ b/playbooks/pxc56_bootstrap.yml
@@ -15,7 +15,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/playbooks/pxc56_common.yml
+++ b/playbooks/pxc56_common.yml
@@ -15,7 +15,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_testing_repo.yml

--- a/playbooks/pxc57_bootstrap.yml
+++ b/playbooks/pxc57_bootstrap.yml
@@ -15,7 +15,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/playbooks/pxc57_clean.yml
+++ b/playbooks/pxc57_clean.yml
@@ -14,10 +14,10 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
-    include: ../tasks/enable_pxc57_testing_repo.yml
+    include_tasks: ../tasks/enable_pxc57_testing_repo.yml
     when: repo == "testing"
 
   - name: download and extract world database

--- a/playbooks/pxc57_common.yml
+++ b/playbooks/pxc57_common.yml
@@ -15,7 +15,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling test repo
     include_tasks: ../tasks/enable_pxc57_testing_repo.yml
@@ -30,7 +30,7 @@
     when: lookup('env', 'install_repo') == "experimental"
 
 # - name: include tasks for enabling experimental repo
-#   include: ../tasks/enable_pxc57_experimental_repo.yml
+#   include_tasks: ../tasks/enable_pxc57_experimental_repo.yml
 
   - name: disable selinux
     selinux: state=disabled

--- a/playbooks/pxc80_bootstrap.yml
+++ b/playbooks/pxc80_bootstrap.yml
@@ -17,7 +17,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/playbooks/pxc80_common.yml
+++ b/playbooks/pxc80_common.yml
@@ -17,7 +17,7 @@
   - debug: var=man_ip
 
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: download and extract world database
     command: "{{ item }}"

--- a/playbooks/repo_upgrade.yml
+++ b/playbooks/repo_upgrade.yml
@@ -4,10 +4,10 @@
 
   tasks:
   - name: include tasks for test env setup
-    include: ../tasks/test_prep.yml
+    include_tasks: ../tasks/test_prep.yml
 
   - name: include tasks for enabling main repo
-    include: ../tasks/enable_main_repo.yml
+    include_tasks: ../tasks/enable_main_repo.yml
 
   - name: list installed packages
     include_tasks: ../tasks/list_installed_packages.yml

--- a/playbooks/upgrade.yml
+++ b/playbooks/upgrade.yml
@@ -7,7 +7,7 @@
 
   tasks:
   - name: include tasks for enabling testing repo
-    include: ../tasks/enable_testing_repo.yml
+    include_tasks: ../tasks/enable_testing_repo.yml
 
   - name: upgrade deb packages
     apt: update_cache=yes upgrade=safe

--- a/tasks/client_check.yml
+++ b/tasks/client_check.yml
@@ -1,39 +1,39 @@
 ---
 # This task installs PS/PXC client and checks that it works correctly
 - name: include tasks for enabling main repo for client_test
-  include: ../tasks/enable_main_repo.yml
+  include_tasks: ../tasks/enable_main_repo.yml
   when: (lookup('env', 'client_to_test') not in ["ps80", "pxc80"]) and (lookup('env', 'repo_for_client_to_test') == "main") and (lookup('env', 'install_repo') != "main")
 
 - name: include tasks for enabling testing repo for client_test
-  include: ../tasks/enable_testing_repo.yml
+  include_tasks: ../tasks/enable_testing_repo.yml
   when: (lookup('env', 'client_to_test') not in ["ps80", "pxc80"]) and (lookup('env', 'repo_for_client_to_test') == "testing") and (lookup('env', 'install_repo') != "testing")
 
 - name: include tasks for enabling experimental repo for client_test
-  include: ../tasks/enable_experimental_repo.yml
+  include_tasks: ../tasks/enable_experimental_repo.yml
   when: (lookup('env', 'client_to_test') not in ["ps80", "pxc80"]) and (lookup('env', 'repo_for_client_to_test') == "experimental") and (lookup('env', 'install_repo') != "experimental")
 
 - name: include tasks for enabling PS 8 main repo for client_test
-  include: ../tasks/enable_ps8_main_repo.yml
+  include_tasks: ../tasks/enable_ps8_main_repo.yml
   when: (lookup('env', 'client_to_test') == "ps80") and (lookup('env', 'repo_for_client_to_test') == "main")
 
 - name: include tasks for enabling PS 8 testing repo for client_test
-  include: ../tasks/enable_ps8_testing_repo.yml
+  include_tasks: ../tasks/enable_ps8_testing_repo.yml
   when: (lookup('env', 'client_to_test') == "ps80") and (lookup('env', 'repo_for_client_to_test') == "testing")
 
 - name: include tasks for enabling PS 8 experimental repo for client_test
-  include: ../tasks/enable_ps8_experimental_repo.yml
+  include_tasks: ../tasks/enable_ps8_experimental_repo.yml
   when: (lookup('env', 'client_to_test') == "ps80") and (lookup('env', 'repo_for_client_to_test') == "experimental")
 
 - name: include tasks for enabling PXC 8 main repo for client_test
-  include: ../tasks/enable_pxc80_main_repo.yml
+  include_tasks: ../tasks/enable_pxc80_main_repo.yml
   when: (lookup('env', 'client_to_test') == "pxc80") and (lookup('env', 'repo_for_client_to_test') == "main")
 
 - name: include tasks for enabling PXC 8 testing repo for client_test
-  include: ../tasks/enable_pxc80_testing_repo.yml
+  include_tasks: ../tasks/enable_pxc80_testing_repo.yml
   when: (lookup('env', 'client_to_test') == "pxc80") and (lookup('env', 'repo_for_client_to_test') == "testing")
 
 - name: include tasks for enabling PXC 8 experimental repo for client_test
-  include: ../tasks/enable_pxc80_experimental_repo.yml
+  include_tasks: ../tasks/enable_pxc80_experimental_repo.yml
   when: (lookup('env', 'client_to_test') == "pxc80") and (lookup('env', 'repo_for_client_to_test') == "experimental")
 
 - name: install deb packages

--- a/tasks/enable_experimental_repo.yml
+++ b/tasks/enable_experimental_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_laboratory_with_main_repo.yml
+++ b/tasks/enable_laboratory_with_main_repo.yml
@@ -1,7 +1,7 @@
 # This task enables laboratory and main repositories
 #
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_main_repo.yml
+++ b/tasks/enable_main_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps82_experimental_repo.yml
+++ b/tasks/enable_ps82_experimental_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps82_main_repo.yml
+++ b/tasks/enable_ps82_main_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps82_testing_repo.yml
+++ b/tasks/enable_ps82_testing_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps8_experimental_repo.yml
+++ b/tasks/enable_ps8_experimental_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps8_main_repo.yml
+++ b/tasks/enable_ps8_main_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps8_testing_repo.yml
+++ b/tasks/enable_ps8_testing_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps_innovation_repo_experimental.yml
+++ b/tasks/enable_ps_innovation_repo_experimental.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps_innovation_repo_main.yml
+++ b/tasks/enable_ps_innovation_repo_main.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_ps_innovation_repo_testing.yml
+++ b/tasks/enable_ps_innovation_repo_testing.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_psmdb_repo.yml
+++ b/tasks/enable_psmdb_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: Install percona repository package for deb based distros
     apt:

--- a/tasks/enable_pt_repos_and_install.yml
+++ b/tasks/enable_pt_repos_and_install.yml
@@ -25,4 +25,4 @@
     command: ../version_check.sh pt
 
   - name: remove pt packages
-    include: ../tasks/remove_pt.yml
+    include_tasks: ../tasks/remove_pt.yml

--- a/tasks/enable_pxc57_experimental_repo.yml
+++ b/tasks/enable_pxc57_experimental_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_pxc57_main_repo.yml
+++ b/tasks/enable_pxc57_main_repo.yml
@@ -1,6 +1,6 @@
 
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_pxc57_testing_repo.yml
+++ b/tasks/enable_pxc57_testing_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_pxc80_experimental_repo.yml
+++ b/tasks/enable_pxc80_experimental_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_pxc80_main_repo.yml
+++ b/tasks/enable_pxc80_main_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_pxc80_testing_repo.yml
+++ b/tasks/enable_pxc80_testing_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_testing_repo.yml
+++ b/tasks/enable_testing_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: disable the mysql module on RHEL/CentOS 8
     command: /usr/bin/dnf module disable mysql -y

--- a/tasks/enable_tools_experimental_repo.yml
+++ b/tasks/enable_tools_experimental_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: Install percona repository package
     apt:

--- a/tasks/enable_tools_main_repo.yml
+++ b/tasks/enable_tools_main_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: install Percona repository package on debian/ubuntu
     apt:

--- a/tasks/enable_tools_testing_repo.yml
+++ b/tasks/enable_tools_testing_repo.yml
@@ -1,5 +1,5 @@
   - name: include playbook for removing Percona repo
-    include: remove_percona_repository.yml
+    include_tasks: remove_percona_repository.yml
 
   - name: Install percona repository package
     apt:


### PR DESCRIPTION
Due to update in the ansible version,

We need to change module value from include: to include_tasks.
Kindly check if your package tests, ansible playbooks/taskbooks are running as per requirement after this change.

Please use this branch while testing.