### PR TITLE
Removed limitation for versions less than 8 for MySQL GPG key upgrade…

### DIFF
--- a/tasks/install_and_run_upstream80.yml
+++ b/tasks/install_and_run_upstream80.yml
@@ -19,7 +19,7 @@
     rpm_key:
       state: present
       key: http://repo.mysql.com/RPM-GPG-KEY-mysql-2023
-    when: ansible_os_family == "RedHat" and ansible_distribution_major_version|int >= 8
+    when: ansible_os_family == "RedHat"
 
   - name: Install MySQL RHEL 8 yum repository package
     yum: name=https://repo.mysql.com/mysql80-community-release-el8-3.noarch.rpm state=present


### PR DESCRIPTION
…, so it will happen for all CentOS/RH/OEL versions