### PR TITLE
pxb tarball debian-11 fix: ami-02dda1c84e46dbe0a

### DIFF
--- a/molecule/pxb-binary-tarball/molecule/debian-11/molecule.yml
+++ b/molecule/pxb-binary-tarball/molecule/debian-11/molecule.yml
@@ -6,7 +6,7 @@ driver:
 platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
     region: us-west-1
-    image: ami-09b4378b1d3387f81
+    image: ami-02dda1c84e46dbe0a
     vpc_subnet_id: subnet-04a8ad1b1d4da874c
     instance_type: t2.large
     ssh_user: admin


### PR DESCRIPTION
https://wiki.debian.org/Cloud/AmazonEC2Image/Bullseye