### PR TITLE
fix(ps80-binary-tarball): tear down molecule EC2 instances on failure

### DIFF
--- a/molecule/ps80-binary-tarball/molecule/al-2023/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/al-2023/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create: ../../../playbooks/create-noble-arm.yml
-    destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -36,10 +36,8 @@ scenario:
   destroy_sequence:
     - destroy
   test_sequence:
-    - destroy
     - create
     - prepare
     - converge
     - verify
     - destroy
-

--- a/molecule/ps80-binary-tarball/molecule/debian-11/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/debian-11/molecule.yml
@@ -37,10 +37,8 @@ scenario:
   destroy_sequence:
     - destroy
   test_sequence:
-    - destroy
     - create
     - prepare
     - converge
     - verify
     - destroy
-

--- a/molecule/ps80-binary-tarball/molecule/debian-12/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/debian-12/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create: ../../../playbooks/create-noble-arm.yml
-  #  destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -33,13 +33,11 @@ verifier:
     FIPS_SUPPORTED: "yes"
 scenario:
   name: debian-12
- # destroy_sequence:
-  #  - destroy
+  destroy_sequence:
+    - destroy
   test_sequence:
-   # - destroy
     - create
     - prepare
     - converge
     - verify
-    #- destroy
-
+    - destroy

--- a/molecule/ps80-binary-tarball/molecule/debian-13/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/debian-13/molecule.yml
@@ -36,7 +36,6 @@ scenario:
   destroy_sequence:
     - destroy
   test_sequence:
-    - destroy
     - create
     - prepare
     - converge

--- a/molecule/ps80-binary-tarball/molecule/oracle-8/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/oracle-8/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create:  ../../playbooks/create.yml
-  #  destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -34,13 +34,11 @@ verifier:
     ANSIBLE_SSH_TRANSFER_METHOD: piped
 scenario:
   name: oracle-8
- # destroy_sequence:
- #   - destroy
+  destroy_sequence:
+    - destroy
   test_sequence:
-  #  - destroy
     - create
     - prepare
     - converge
     - verify
-  #  - destroy
-
+    - destroy

--- a/molecule/ps80-binary-tarball/molecule/oracle-9/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/oracle-9/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create:  ../../playbooks/create.yml
-  #  destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -34,13 +34,11 @@ verifier:
     ANSIBLE_SSH_TRANSFER_METHOD: piped
 scenario:
   name: oracle-9
- # destroy_sequence:
- #   - destroy
+  destroy_sequence:
+    - destroy
   test_sequence:
-  #  - destroy
     - create
     - prepare
     - converge
     - verify
-  #  - destroy
-
+    - destroy

--- a/molecule/ps80-binary-tarball/molecule/rhel-10/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/rhel-10/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create:  ../../playbooks/create.yml
-  #  destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -34,13 +34,11 @@ verifier:
     ANSIBLE_SSH_TRANSFER_METHOD: piped
 scenario:
   name: rhel-10
- # destroy_sequence:
- #   - destroy
+  destroy_sequence:
+    - destroy
   test_sequence:
-  #  - destroy
     - create
     - prepare
     - converge
     - verify
-  #  - destroy
-
+    - destroy

--- a/molecule/ps80-binary-tarball/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/ubuntu-jammy/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create: ../../../playbooks/create-noble-arm.yml
-   # destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -33,12 +33,11 @@ verifier:
     FIPS_SUPPORTED: "no"
 scenario:
   name: ubuntu-jammy
-#  destroy_sequence:
-#    - destroy
+  destroy_sequence:
+    - destroy
   test_sequence:
- #   - destroy
     - create
     - prepare
     - converge
     - verify
- #   - destroy
+    - destroy

--- a/molecule/ps80-binary-tarball/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/ubuntu-noble/molecule.yml
@@ -20,7 +20,7 @@ provisioner:
   log: True
   playbooks:
     create: ../../../playbooks/create-noble-arm.yml
-    destroy: ../../../playbooks/destroy-noble-arm.yml
+    destroy: ../../playbooks/destroy.yml
     prepare: ../../playbooks/prepare.yml
     converge: ../../playbooks/playbook.yml
 verifier:
@@ -36,10 +36,8 @@ scenario:
   destroy_sequence:
     - destroy
   test_sequence:
-    - destroy
     - create
     - prepare
     - converge
     - verify
     - destroy
-

--- a/molecule/ps80-binary-tarball/playbooks/destroy.yml
+++ b/molecule/ps80-binary-tarball/playbooks/destroy.yml
@@ -1,0 +1,31 @@
+---
+- name: Destroy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+  no_log: "{{ not (lookup('env', 'MOLECULE_DEBUG') | bool or molecule_yml.provisioner.log|default(false) | bool) }}"
+  vars:
+    default_region: "{{ lookup('env', 'AWS_DEFAULT_REGION') | default('us-east-1', true) }}"
+
+  tasks:
+    # Terminate by the unique Name tag set in create.yml (item.name already embeds
+    # BUILD_NUMBER + JOB_NAME, so it is unique to this run and cannot match unrelated
+    # instances). This works even when molecule instance-config was never written.
+    - name: Destroy molecule instance(s)
+      amazon.aws.ec2_instance:
+        state: absent
+        filters:
+          "tag:Name": "{{ item.name }}"
+          instance-state-name:
+            - pending
+            - running
+            - stopping
+            - stopped
+        region: "{{ item.region|default(default_region) }}"
+        wait: true
+      with_items: "{{ molecule_yml.platforms }}"
+      register: server
+
+    - name: Print destroy result
+      debug:
+        var: server


### PR DESCRIPTION
## Bug

- The `ps80-binary-tarball` molecule scenarios never tear down their EC2 instances: each `molecule/<os>/molecule.yml` has `destroy` commented out of `test_sequence` and no destroy playbook wired, and `playbooks/destroy.yml` does not exist.
- A failing OS run therefore leaves its instance running. 48 on-demand VMs leaked across builds 191-198 of the `test-ps-binary-tarball` job (6 per build) and were terminated manually.

## Fix

- Add `playbooks/destroy.yml` that terminates by the unique `Name` tag (`<os>-${BUILD_NUMBER}-${JOB_NAME}`, scoped to the platform region). It reads `molecule_yml.platforms[].name`, the same value `create.yml` tags as `Name`, so teardown works even when molecule instance-config was never written (early create/SSH failures).
- Re-enable `destroy` as the final step of `test_sequence` and add `destroy_sequence` across all 9 EC2 scenarios, so molecule tears down on success and on verify/converge failure.

## Notes

- Termination keys on the run-unique `Name`, so it cannot affect another build or job. The pipeline `post { always } molecule destroy` is the backstop and now resolves to a working destroy playbook.
