### PR TITLE
Replace deleted VPC subnet IDs with current ones

### DIFF
--- a/molecule/configuration.yml
+++ b/molecule/configuration.yml
@@ -1,91 +1,91 @@
 centos-6:
   image: ami-07fa74e425f2abf29
   user: centos
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 centos-7:
   image: ami-04cf43aca3e6f3de3
   user: centos
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 centos-8:
   image: ami-0034c84e4e9c557bd
   user: centos
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 debian-8:
   image: ami-abff2ac4
   user: admin
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/xvda
 debian-9:
   image: ami-006c08e13f35edce0
   user: admin
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: xvda
 debian-10:
   image: ami-0be88f8d647409e61
   user: admin
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: xvda
 ubuntu-cosmic:
   image: ami-0ead033d778487b37
   user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-disco:
   image: ami-084a12ae4a0c27ea7
   user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-bionic:
   image: ami-0a8561d8c5a4f098a
   user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-xenial:
   image: ami-44182caf
   user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-focal:
   image: ami-00ffef8efdbc08528
   user: ubuntu
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 rhel8:
   image: ami-0badcc5b522737046
   user: ec2-user
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/sda1
 amazonlinux-2:
   image: ami-074dc9dd588b6ea52
   user: ec2-user
-  subnet: subnet-085deaca8c1c59a4f
+  subnet: subnet-0129be02b1e99d0a1
   aws_default_region: eu-central-1
   instance_type: t2.micro
   root_device_name: /dev/xvda

--- a/molecule/configuration_west.yml
+++ b/molecule/configuration_west.yml
@@ -1,84 +1,84 @@
 centos-6:
   image: ami-0362922178e02e9f3
   user: centos
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 centos-7:
   image: ami-036d2cdf95d86d256
   user: centos
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 centos-8:
   image: ami-0af9de0b0b4d7fbb0
   user: root
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 debian-8:
   image: ami-4e1cc32e
   user: admin
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: xvda
 debian-9:
   image: ami-01d07e14f082b3ba1
   user: admin
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: xvda
 debian-10:
   image: ami-0f5d8e2951e3f83a5
   user: admin
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: xvda
 ubuntu-cosmic:
   image: ami-0ead033d778487b37
   user: ubuntu
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-disco:
   image: ami-084a12ae4a0c27ea7
   user: ubuntu
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-bionic:
   image: ami-01946830552766aa5
   user: ubuntu
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-xenial:
   image: ami-056f971efe114915a
   user: ubuntu
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 ubuntu-focal:
   image: ami-05a98b3bebe1b280e
   user: ubuntu
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1
 rhel8:
   image: ami-087c2c50437d0b80d
   user: ec2-user
-  subnet: subnet-03136d8c244f56036
+  subnet: subnet-0430e63d7cdbcd237
   aws_default_region: us-west-2
   instance_type: t2.micro
   root_device_name: /dev/sda1

--- a/molecule/pbm/install/molecule/centos-6/molecule.yml
+++ b/molecule/pbm/install/molecule/centos-6/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos6-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0362922178e02e9f3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pbm/install/molecule/centos-7/molecule.yml
+++ b/molecule/pbm/install/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-036d2cdf95d86d256
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pbm/install/molecule/debian-10/molecule.yml
+++ b/molecule/pbm/install/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pbm/install/molecule/debian-11/molecule.yml
+++ b/molecule/pbm/install/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-05f9dcaa9ddb9a15e
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pbm/install/molecule/debian-9/molecule.yml
+++ b/molecule/pbm/install/molecule/debian-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01d07e14f082b3ba1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pbm/install/molecule/rhel8/molecule.yml
+++ b/molecule/pbm/install/molecule/rhel8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-087c2c50437d0b80d
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pbm/install/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pbm/install/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pbm/install/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pbm/install/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pbm/install/molecule/ubuntu-xenial/molecule.yml
+++ b/molecule/pbm/install/molecule/ubuntu-xenial/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uxenial-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0813245c0939ab3ca
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pbm/upgrade/molecule/centos-6/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/centos-6/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos6-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0362922178e02e9f3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pbm/upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-036d2cdf95d86d256
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pbm/upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pbm/upgrade/molecule/debian-9/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/debian-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01d07e14f082b3ba1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pbm/upgrade/molecule/rhel8/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/rhel8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-087c2c50437d0b80d
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pbm/upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pbm/upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pbm/upgrade/molecule/ubuntu-xenial/molecule.yml
+++ b/molecule/pbm/upgrade/molecule/ubuntu-xenial/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uxenial-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0813245c0939ab3ca
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/haproxy/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pdmysql/haproxy/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-0a8561d8c5a4f098a
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/orchestrator/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pdmysql/orchestrator/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/orchestrator/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pdmysql/orchestrator/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/al-2023/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps/molecule/amazon-2/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/amazon-2/molecule.yml
@@ -5,7 +5,7 @@ platforms:
   - name: am2-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0f9f005c313373218
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps/molecule/centos-7/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/debian-10/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pdmysql/pdps/molecule/debian-11/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01ce1f232a5e4adc2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps/molecule/debian-12/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps/molecule/debian-13/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps/molecule/oracle-8/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/oracle-9/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/rhel-10/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/rhel-8/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/rhel-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/rhel-9/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pdmysql/pdps/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/al-2023/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/amazon-2/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/amazon-2/molecule.yml
@@ -5,7 +5,7 @@ platforms:
   - name: am2-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0f9f005c313373218
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/centos-7/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-036d2cdf95d86d256
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-10/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-11/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01ce1f232a5e4adc2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-12/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-13/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/oracle-8/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/oracle-9/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/rhel-10/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/rhel-8/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/rhel-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/rhel-9/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/pdmysql/pdps_minor_upgrade/molecule/ubuntu-noble/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoble-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/al-2023/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_setup/molecule/amazon-2/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/amazon-2/molecule.yml
@@ -5,7 +5,7 @@ platforms:
   - name: am2-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0f9f005c313373218
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_setup/molecule/centos-7/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-036d2cdf95d86d256
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/debian-10/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/pdmysql/pdps_setup/molecule/debian-11/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01ce1f232a5e4adc2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_setup/molecule/debian-12/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_setup/molecule/debian-13/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdps_setup/molecule/oracle-8/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/oracle-9/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/rhel-10/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/rhel-8/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/rhel-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/rhel-9/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdps_setup/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pdmysql/pdps_setup/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pdmysql/pdpxc/molecule/al-2023/molecule.yml
+++ b/molecule/pdmysql/pdpxc/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0cc96c4cd98401dae
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdpxc_minor_upgrade/molecule/al-2023/molecule.yml
+++ b/molecule/pdmysql/pdpxc_minor_upgrade/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0cc96c4cd98401dae
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pdmysql/pdpxc_setup/molecule/al-2023/molecule.yml
+++ b/molecule/pdmysql/pdpxc_setup/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0cc96c4cd98401dae
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/prel/molecule/centos-7/molecule.yml
+++ b/molecule/prel/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-04cf43aca3e6f3de3
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/prel/molecule/centos-8/molecule.yml
+++ b/molecule/prel/molecule/centos-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos8-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-032025b3afcbb6b34
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/prel/molecule/debian-10/molecule.yml
+++ b/molecule/prel/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-0be88f8d647409e61
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/prel/molecule/debian-11/molecule.yml
+++ b/molecule/prel/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-007428d10865c9957
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/prel/molecule/debian-9/molecule.yml
+++ b/molecule/prel/molecule/debian-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian9-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-006c08e13f35edce0
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/prel/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/prel/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-0a8561d8c5a4f098a
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/prel/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/prel/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-0be656e75e69af1a9
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/prel/molecule/ubuntu-xenial/molecule.yml
+++ b/molecule/prel/molecule/ubuntu-xenial/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uxenial-${BUILD_NUMBER}-${JOB_NAME}
     region: eu-central-1
     image: ami-44182caf
-    vpc_subnet_id: subnet-085deaca8c1c59a4f
+    vpc_subnet_id: subnet-0129be02b1e99d0a1
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/al-2023-arm/molecule.yml
+++ b/molecule/proxysql/molecule/al-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-00478270b6d87a5d1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/al-2023/molecule.yml
+++ b/molecule/proxysql/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-043ab4148b7bb33e9
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/debian-11-arm/molecule.yml
+++ b/molecule/proxysql/molecule/debian-11-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0a4fc89e459b5c142
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/debian-11/molecule.yml
+++ b/molecule/proxysql/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-01ce1f232a5e4adc2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/debian-12-arm/molecule.yml
+++ b/molecule/proxysql/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/debian-12/molecule.yml
+++ b/molecule/proxysql/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/debian-13-arm/molecule.yml
+++ b/molecule/proxysql/molecule/debian-13-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00f9bd78b9eb2c2d0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/debian-13/molecule.yml
+++ b/molecule/proxysql/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/proxysql/molecule/oracle-8/molecule.yml
+++ b/molecule/proxysql/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/oracle-9/molecule.yml
+++ b/molecule/proxysql/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/proxysql/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/rhel-10/molecule.yml
+++ b/molecule/proxysql/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/rhel-8-arm/molecule.yml
+++ b/molecule/proxysql/molecule/rhel-8-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-arm-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/rhel-9-arm/molecule.yml
+++ b/molecule/proxysql/molecule/rhel-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/rhel-9/molecule.yml
+++ b/molecule/proxysql/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/ubuntu-focal-arm/molecule.yml
+++ b/molecule/proxysql/molecule/ubuntu-focal-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0a5713dbf2d1876cd
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/proxysql/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/proxysql/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/proxysql/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/ubuntu-noble-arm/molecule.yml
+++ b/molecule/proxysql/molecule/ubuntu-noble-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoblearm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0f3b814f07ac0db32
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/proxysql/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/proxysql/molecule/ubuntu-noble/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoble-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0aff18ec83b712f05
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/downgrade/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-80-pro/downgrade/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/downgrade/molecule/debian-12/molecule.yml
+++ b/molecule/ps-80-pro/downgrade/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/downgrade/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-80-pro/downgrade/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/downgrade/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-80-pro/downgrade/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/downgrade/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-80-pro/downgrade/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/downgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-80-pro/downgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/install/molecule/amazon-linux-2023-arm/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/amazon-linux-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/install/molecule/amazon-linux-2023/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/amazon-linux-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/install/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/install/molecule/debian-12/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0dbd0b6509fe8f301
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/install/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/install/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/install/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-80-pro/install/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/not_pro_to_pro/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-80-pro/not_pro_to_pro/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/not_pro_to_pro/molecule/debian-12/molecule.yml
+++ b/molecule/ps-80-pro/not_pro_to_pro/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/not_pro_to_pro/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-80-pro/not_pro_to_pro/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/not_pro_to_pro/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-80-pro/not_pro_to_pro/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/not_pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-80-pro/not_pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/not_pro_to_pro/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-80-pro/not_pro_to_pro/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/pro_to_pro/molecule/amazon-linux-2023-arm/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/amazon-linux-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/pro_to_pro/molecule/amazon-linux-2023/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/amazon-linux-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/pro_to_pro/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/pro_to_pro/molecule/debian-12/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-80-pro/pro_to_pro/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/pro_to_pro/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-80-pro/pro_to_pro/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-80-pro/pro_to_pro/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/downgrade/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/downgrade/molecule/debian-12/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/downgrade/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/downgrade/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/downgrade/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/downgrade/molecule/rhel-10/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/downgrade/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/downgrade/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-84-pro/downgrade/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/amazon-linux-2023-arm/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/amazon-linux-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/amazon-linux-2023/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/amazon-linux-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/install/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/install/molecule/debian-12/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/install/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/rhel-10/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/install/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-84-pro/install/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/debian-12/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/rhel-10/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/not_pro_to_pro/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-84-pro/not_pro_to_pro/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/amazon-linux-2023-arm/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/amazon-linux-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/amazon-linux-2023/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/amazon-linux-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/pro_to_pro/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/pro_to_pro/molecule/debian-12/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps-84-pro/pro_to_pro/molecule/oracle-9-arm/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/oracle-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/oracle-9/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10arm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/rhel-10/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image:  ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-84-pro/pro_to_pro/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-84-pro/pro_to_pro/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${cur_action_to_test}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/al-2023-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/al-2023-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-al-2023-arm
     region: us-west-2
     image: ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/al-2023/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/al-2023/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-al-2023
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps-innodb-cluster/router/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/rhel-10-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-rhel-10-arm
     region: us-west-2
     image: ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/rhel-10/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/rhel-10/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-rhel-10
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/rhel-8-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/rhel-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-rhel-8-arm
     region: us-west-2
     image: ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/rhel-8/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/rhel-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-rhel-8
     region: us-west-2
     image: ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/rhel-9-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/rhel-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-rhel-9-arm
     region: us-west-2
     image: ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/rhel-9/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/rhel-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-rhel-9
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/ubuntu-jammy-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-ubuntu-jammy-arm
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/router/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-innodb-cluster/router/molecule/ubuntu-jammy/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: mysql-router-ubuntu-jammy
     region: us-west-2
     image: ami-00b0c1efb144c2176
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/al-2023-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/al-2023-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-al-2023-arm
     region: us-west-2
     image: ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-al-2023-arm
     region: us-west-2
     image: ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-al-2023-arm
     region: us-west-2
     image: ami-0c7104b910fd5acb5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/al-2023/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/al-2023/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-al-2023
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-al-2023
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-al-2023
     region: us-west-2
     image: ami-0005ee01bca55ab66
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps-innodb-cluster/server/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/rhel-10-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-rhel-10-arm
     region: us-west-2
     image: ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-rhel-10-arm
     region: us-west-2
     image: ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-rhel-10-arm
     region: us-west-2
     image: ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/rhel-10/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/rhel-10/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-rhel-10
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-rhel-10
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-rhel-10
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/rhel-8-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/rhel-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-rhel-8-arm
     region: us-west-2
     image: ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-rhel-8-arm
     region: us-west-2
     image: ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-rhel-8-arm
     region: us-west-2
     image: ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/rhel-8/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/rhel-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-rhel-8
     region: us-west-2
     image: ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-rhel-8
     region: us-west-2
     image: ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-rhel-8
     region: us-west-2
     image: ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/rhel-9-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/rhel-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-rhel-9-arm
     region: us-west-2
     image: ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-rhel-9-arm
     region: us-west-2
     image: ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-rhel-9-arm
     region: us-west-2
     image: ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/rhel-9/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/rhel-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-rhel-9
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-rhel-9
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-rhel-9
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/ubuntu-jammy-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-ubuntu-jammy-arm
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-ubuntu-jammy-arm
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-ubuntu-jammy-arm
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps-innodb-cluster/server/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps-innodb-cluster/server/molecule/ubuntu-jammy/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ps-node1-ubuntu-jammy
     region: us-west-2
     image: ami-00b0c1efb144c2176
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -20,7 +20,7 @@ platforms:
   - name: ps-node2-ubuntu-jammy
     region: us-west-2
     image: ami-00b0c1efb144c2176
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1
@@ -31,7 +31,7 @@ platforms:
   - name: ps-node3-ubuntu-jammy
     region: us-west-2
     image: ami-00b0c1efb144c2176
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/amazon-linux-2/molecule.yml
+++ b/molecule/ps/molecule/amazon-linux-2/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0648742c7600c103f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/amazon-linux-2023-arm/molecule.yml
+++ b/molecule/ps/molecule/amazon-linux-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0493fed4130eafff5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/amazon-linux-2023/molecule.yml
+++ b/molecule/ps/molecule/amazon-linux-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al2023-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-00563078bca04e287
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/centos-7/molecule.yml
+++ b/molecule/ps/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-04f798ca92cc13f74
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/debian-10/molecule.yml
+++ b/molecule/ps/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-05be179483264959d
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/debian-11-arm/molecule.yml
+++ b/molecule/ps/molecule/debian-11-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0a4fc89e459b5c142
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/debian-11/molecule.yml
+++ b/molecule/ps/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-01ce1f232a5e4adc2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/debian-12-arm/molecule.yml
+++ b/molecule/ps/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/debian-12/molecule.yml
+++ b/molecule/ps/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/debian-13-arm/molecule.yml
+++ b/molecule/ps/molecule/debian-13-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00f9bd78b9eb2c2d0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/debian-13/molecule.yml
+++ b/molecule/ps/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t3.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps/molecule/oracle-8/molecule.yml
+++ b/molecule/ps/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/oracle-9/molecule.yml
+++ b/molecule/ps/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/ps/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rhel-10/molecule.yml
+++ b/molecule/ps/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rhel-8-arm/molecule.yml
+++ b/molecule/ps/molecule/rhel-8-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-arm-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rhel-8/molecule.yml
+++ b/molecule/ps/molecule/rhel-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rhel-9-arm/molecule.yml
+++ b/molecule/ps/molecule/rhel-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rhel-9/molecule.yml
+++ b/molecule/ps/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rocky-8-arm/molecule.yml
+++ b/molecule/ps/molecule/rocky-8-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-8-arm-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rocky-8/molecule.yml
+++ b/molecule/ps/molecule/rocky-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-8-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rocky-9-arm/molecule.yml
+++ b/molecule/ps/molecule/rocky-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-9-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/rocky-9/molecule.yml
+++ b/molecule/ps/molecule/rocky-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: rocky
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-focal-arm/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-focal-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0a5713dbf2d1876cd
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammyarm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-resolute-arm/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-resolute-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uresolutearm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0dc008cec48891123
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t4g.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/ps/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uresolute-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t3.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball-pro/molecule/al-2023/molecule.yml
+++ b/molecule/ps80-binary-tarball-pro/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01634322a170b5fd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps80-binary-tarball-pro/molecule/debian-12/molecule.yml
+++ b/molecule/ps80-binary-tarball-pro/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps80-binary-tarball-pro/molecule/oracle-9/molecule.yml
+++ b/molecule/ps80-binary-tarball-pro/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball-pro/molecule/rhel-10/molecule.yml
+++ b/molecule/ps80-binary-tarball-pro/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball-pro/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps80-binary-tarball-pro/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball-pro/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/ps80-binary-tarball-pro/molecule/ubuntu-noble/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-noble-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0cf2b4e024cdb6960
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball/molecule/al-2023/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-01634322a170b5fd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/ps80-binary-tarball/molecule/debian-11/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-02d0122d25353b012
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps80-binary-tarball/molecule/debian-12/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0dbd0b6509fe8f301
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps80-binary-tarball/molecule/debian-13/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t3.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/ps80-binary-tarball/molecule/oracle-8/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball/molecule/oracle-9/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball/molecule/rhel-10/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-058168290d30b9c52
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/ubuntu-noble/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-noble-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0cf2b4e024cdb6960
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/ps80-binary-tarball/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/ps80-binary-tarball/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-resolute-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-binary-tarball/molecule/rhel-10/molecule.yml
+++ b/molecule/pxb-binary-tarball/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-inc-backup-load/molecule/rhel-10/molecule.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-inc-backup-load/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-resolute-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-innodb-rocksdb/molecule/rhel-10/molecule.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-innodb-rocksdb/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-resolute-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-replication/molecule/rhel-10/molecule.yml
+++ b/molecule/pxb-new-ps-replication/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-replication/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/pxb-new-ps-replication/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-resolute-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-upgrade/molecule/rhel-10/molecule.yml
+++ b/molecule/pxb-new-ps-upgrade/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
     region: us-west-2
     image: ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-upgrade/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/pxb-new-ps-upgrade/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubuntu-resolute-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/al-2023-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/al-2023-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0493fed4130eafff5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/al-2023/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00563078bca04e287
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/centos-7/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/debian-11-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/debian-11-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0a4fc89e459b5c142
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/debian-11/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-01ce1f232a5e4adc2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/debian-12-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/debian-12/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/debian-13-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/debian-13-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00f9bd78b9eb2c2d0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/debian-13/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/debian-13/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian13-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-081ac37fe26dacc98
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/oracle-8/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/oracle-9/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rhel-10-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rhel-10-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0ee25ba03b69968c5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rhel-10/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rhel-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel10-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0987e9d53da324257
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rhel-8-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rhel-8-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-arm-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rhel-8/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rhel-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0be9dd52e05f424f3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rhel-9-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rhel-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rhel-9/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/rocky-8-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rocky-8-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-8-arm-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.xlarge
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/rocky-8/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rocky-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-8-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-02dd44a54586c69fb
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/rocky-9-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rocky-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-9-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.xlarge
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/rocky-9/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/rocky-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky-9-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image:  ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxb-package-testing/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/ubuntu-noble-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-noble-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoble-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0f3b814f07ac0db32
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-noble/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoble-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0cf2b4e024cdb6960
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/ubuntu-resolute-arm/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-resolute-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uresolute-arm-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0dc008cec48891123
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxb-package-testing/molecule/ubuntu-resolute/molecule.yml
+++ b/molecule/pxb-package-testing/molecule/ubuntu-resolute/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: uresolute-${BUILD_NUMBER}-${JOB_NAME}-${PLAYBOOK_VAR}
     region: us-west-2
     image: ami-0d13e2317a7e75c95
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-8-arm/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-80-bootstrap-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-8/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-80-bootstrap-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-9-arm/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-80-bootstrap-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-9/molecule.yml
+++ b/molecule/pxc/pxc80-bootstrap-install/molecule/rocky-linux-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-80-bootstrap-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/rocky-linux-8-arm/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/rocky-linux-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-80-common-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-80-common-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/rocky-linux-8/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/rocky-linux-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-80-common-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -26,7 +26,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-80-common-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/rocky-linux-9-arm/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/rocky-linux-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-80-common-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -26,7 +26,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-80-common-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image:  ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc80-common-install/molecule/rocky-linux-9/molecule.yml
+++ b/molecule/pxc/pxc80-common-install/molecule/rocky-linux-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-80-common-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -26,7 +26,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-80-common-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-8-arm/molecule.yml
+++ b/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-84-bootstrap-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-8/molecule.yml
+++ b/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-84-bootstrap-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-9-arm/molecule.yml
+++ b/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-84-bootstrap-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-9/molecule.yml
+++ b/molecule/pxc/pxc84-bootstrap-install/molecule/rocky-linux-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-84-bootstrap-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-common-install/molecule/rocky-linux-8-arm/molecule.yml
+++ b/molecule/pxc/pxc84-common-install/molecule/rocky-linux-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-84-common-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-84-common-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-common-install/molecule/rocky-linux-8/molecule.yml
+++ b/molecule/pxc/pxc84-common-install/molecule/rocky-linux-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-84-common-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-84-common-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-common-install/molecule/rocky-linux-9-arm/molecule.yml
+++ b/molecule/pxc/pxc84-common-install/molecule/rocky-linux-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-84-common-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-84-common-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc84-common-install/molecule/rocky-linux-9/molecule.yml
+++ b/molecule/pxc/pxc84-common-install/molecule/rocky-linux-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-84-common-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-84-common-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-8-arm/molecule.yml
+++ b/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-innovation-bootstrap-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-8/molecule.yml
+++ b/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-innovation-bootstrap-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-9-arm/molecule.yml
+++ b/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-innovation-bootstrap-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-9/molecule.yml
+++ b/molecule/pxc/pxc_innovation-bootstrap-install/molecule/rocky-linux-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc1-innovation-bootstrap-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-8-arm/molecule.yml
+++ b/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-8-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-innovation-common-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-innovation-common-rl-8-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-0d4e5716e8f0b62b0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-8/molecule.yml
+++ b/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-8/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-innovation-common-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-innovation-common-rl-8-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-04310224db1f2a278
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-9-arm/molecule.yml
+++ b/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-9-arm/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-innovation-common-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-innovation-common-rl-9-arm-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-09aad1f3c008ab0b4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-9/molecule.yml
+++ b/molecule/pxc/pxc_innovation-common-install/molecule/rocky-linux-9/molecule.yml
@@ -9,7 +9,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc2-innovation-common-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda
@@ -20,7 +20,7 @@ platforms:
   - name: ${BUILD_NUMBER}-pxc3-innovation-common-rl-9-install-${INSTALLTYPE}
     region: us-west-2
     image: ami-023eeffe03f0dd455
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: rocky
     root_device_name: /dev/xvda

--- a/molecule/telemetry/telemetry-ps/molecule/amazon-2/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/amazon-2/molecule.yml
@@ -5,7 +5,7 @@ platforms:
   - name: am2-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0f9f005c313373218
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/telemetry/telemetry-ps/molecule/centos-7/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/centos-7/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: centos7-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0686851c4e7b1a8e1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: centos
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/debian-10/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/debian-10/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian10-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0f5d8e2951e3f83a5
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: xvda

--- a/molecule/telemetry/telemetry-ps/molecule/debian-11-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/debian-11-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image: ami-07238559d15dfb99a
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/telemetry/telemetry-ps/molecule/debian-11/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/debian-11/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian11-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0d0f7602aa5c2425d
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/telemetry/telemetry-ps/molecule/debian-12-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/debian-12-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image: ami-093939e1f4317142c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/telemetry/telemetry-ps/molecule/debian-12/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/debian-12/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: debian12-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0544719b13af6edc3
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: admin
     root_device_name: /dev/xvda

--- a/molecule/telemetry/telemetry-ps/molecule/oracle-8/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/oracle-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-0c32e4ead7507bc6f
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/oracle-9/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/oracle-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/rhel-8-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/rhel-8-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image:  ami-0bb199dd39edd7d71
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/rhel-8/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/rhel-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-08970fb2e5767e3b8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/rhel-9-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/rhel-9-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image: ami-0d8185e750f8dfbd0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/rhel-9/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/rhel-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rhel9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-04a616933df665b44
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/rocky-8/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/rocky-8/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky8-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-08748ab6e1dc7d1c8
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: rocky
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/rocky-9/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/rocky-9/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: rocky9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-093bd987f8e53e1f2
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: rocky
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-bionic/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-bionic/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ubionic-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-06ffade19910cbfc0
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.micro
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-focal-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-focal-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image: ami-0570c9d51831648fb
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-focal/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-focal/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ufocal-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-09dd2e08d601bff67
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-jammy-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-jammy-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image: ami-00415b9066218a528
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-jammy/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-jammy/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: ujammy-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0ee8244746ec5d6d4
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-noble-arm/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-noble-arm/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoble-${BUILD_NUMBER}-${JOB_NAME}-arm
     region: us-west-2
     image: ami-0f3b814f07ac0db32
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: c6g.large
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/telemetry/telemetry-ps/molecule/ubuntu-noble/molecule.yml
+++ b/molecule/telemetry/telemetry-ps/molecule/ubuntu-noble/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: unoble-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-0cf2b4e024cdb6960
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.small
     ssh_user: ubuntu
     root_device_name: /dev/sda1

--- a/molecule/test-pxc-binary-tarball-pro/molecule/al-2023/molecule.yml
+++ b/molecule/test-pxc-binary-tarball-pro/molecule/al-2023/molecule.yml
@@ -7,7 +7,7 @@ platforms:
   - name: al-2023-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image: ami-087f352c165340ea1
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: ec2-user
     root_device_name: /dev/xvda

--- a/molecule/test-pxc-binary-tarball-pro/molecule/oracle-9/molecule.yml
+++ b/molecule/test-pxc-binary-tarball-pro/molecule/oracle-9/molecule.yml
@@ -8,7 +8,7 @@ platforms:
   - name: ol9-${BUILD_NUMBER}-${JOB_NAME}
     region: us-west-2
     image:  ami-00a5d5bcea31bb02c
-    vpc_subnet_id: subnet-03136d8c244f56036
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.medium
     ssh_user: ec2-user
     root_device_name: /dev/sda1


### PR DESCRIPTION
**Bug**
- Molecule jobs fail at "Populate subnet vpc" with "list object has no element 0": the hardcoded `vpc_subnet_id` no longer exists, so the `ec2_vpc_subnet_info` lookup returns an empty list
- `subnet-03136d8c244f56036` (305 files) was deleted with the old psmdb VPC in the 2026-06-10 Jenkins master Terraform migration; `subnet-085deaca8c1c59a4f` (10 files, eu-central-1) was deleted in an earlier migration wave

**Fix**
- `subnet-03136d8c244f56036` -> `subnet-0430e63d7cdbcd237` (molecule-tests-ps80, us-west-2b, public; the dedicated QA VPC ~52 scenario files already use, now Terraform-managed)
- `subnet-085deaca8c1c59a4f` -> `subnet-0129be02b1e99d0a1` (jenkins-ps57 VPC, eu-central-1b, public)

**Reported**
- Puneet Kaushik and Yash Panchal in [#opensource-jenkins](https://perconacorp.slack.com/archives/C03FZ570M/p1781091491412429)