### PR TITLE
PS-11200 Support running PXB tests from release branches

### DIFF
--- a/molecule/pxb-new-ps-inc-backup-load/molecule/oracle-9/molecule.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/molecule/oracle-9/molecule.yml
@@ -5,9 +5,9 @@ driver:
   name: ec2
 platforms:
   - name: ol9-${BUILD_NUMBER}-${BUILD_NUMBER}-${JOB_NAME}-pxb-tarball
-    region: us-west-1
-    image: ami-0d1958c85fb6a7b3e
-    vpc_subnet_id: subnet-04a8ad1b1d4da874c
+    region: us-west-2
+    image:  ami-00a5d5bcea31bb02c
+    vpc_subnet_id: subnet-0430e63d7cdbcd237
     instance_type: t2.large
     ssh_user: ec2-user
     root_device_name: /dev/sda1

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -233,6 +233,28 @@
         state: present
       when: ansible_os_family == "RedHat"
 
+    # Pin openssl-devel to the EXACT version already installed as openssl-libs.
+    # On older OL9 AMIs, a plain "openssl-devel" install pulls in a newer
+    # openssl-libs (libcrypto.so.3), swapping the shared crypto lib out from
+    # under the running sshd. New sshd sessions then crash during key exchange
+    # ("Connection reset by peer" / scp "Connection closed") and the host goes
+    # unreachable mid-run (prepare or converge). Installing the matching version
+    # means openssl-libs is already satisfied, so nothing is upgraded and sshd is
+    # never disturbed. RedHat-only (Debian's libssl-dev is unaffected).
+    - name: Gather installed package facts (RedHat)
+      ansible.builtin.package_facts:
+        manager: rpm
+      when: ansible_os_family == "RedHat"
+
+    - name: Install openssl-devel pinned to installed openssl-libs version (RedHat)
+      ansible.builtin.dnf:
+        name: "openssl-devel-{{ ansible_facts.packages['openssl-libs'][0].version }}-{{ ansible_facts.packages['openssl-libs'][0].release }}"
+        state: present
+        allow_downgrade: true
+      when:
+        - ansible_os_family == "RedHat"
+        - "'openssl-libs' in ansible_facts.packages"
+
     - name: Install cmake and build tools for Debian family
       apt:
         name:
@@ -332,17 +354,3 @@
         state: latest
         update_cache: yes
       when: ansible_os_family == "Debian"
-
-    # Keep this as the LAST step of the playbook. Installing openssl-devel can
-    # transitively upgrade openssl-libs (libcrypto.so.3) on older OL9 images,
-    # swapping the shared crypto lib out from under the running sshd. Newly-forked
-    # sshd sessions then crash during key exchange ("Connection reset by peer" /
-    # scp "Connection closed") and the host becomes unreachable. By doing it last,
-    # all other prepare tasks have already completed, so a broken connection here
-    # no longer aborts the rest of the playbook. RedHat-only (Debian's libssl-dev
-    # is installed above with the other build tools and does not have this issue).
-    - name: Install openssl-devel for RedHat family (last to avoid sshd disconnect)
-      package:
-        name: openssl-devel
-        state: present
-      when: ansible_os_family == "RedHat"

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -226,11 +226,24 @@
           - make
           - gcc
           - gcc-c++
+          - openssl-devel
           - zlib-devel
           - libzstd-devel
           - lz4
           - zstd
         state: present
+      when: ansible_os_family == "RedHat"
+
+    # Installing openssl-devel can transitively upgrade openssl-libs (libcrypto.so.3)
+    # on older OL9 images. That swaps the shared crypto lib out from under the
+    # running sshd, so newly-forked sshd sessions crash during key exchange
+    # ("Connection reset by peer" / scp "Connection closed") and the host becomes
+    # unreachable mid-prepare. Restarting sshd makes it re-exec against the new
+    # libcrypto so subsequent connections work. RedHat-only (Debian is unaffected).
+    - name: Restart sshd after openssl-libs may have been upgraded (RedHat)
+      ansible.builtin.service:
+        name: sshd
+        state: restarted
       when: ansible_os_family == "RedHat"
 
     - name: Install cmake and build tools for Debian family

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -1,25 +1,9 @@
----
 - name: Prepare node for running tests
   hosts: all
   become: true
   become_method: sudo
   gather_facts: true
   tasks:
-    - name: Setup SSH keys for RedHat
-      authorized_key:
-        user: ec2-user
-        key: "{{ lookup('file', 'public_keys') }}"
-        state: present
-        exclusive: False
-      when: ansible_os_family == "RedHat"
-      
-    - name: Setup SSH keys CentOS
-      authorized_key:
-        user: centos
-        key: "{{ lookup('file', 'public_keys') }}"
-        state: present
-        exclusive: False
-      when: ansible_distribution == "CentOS"
 
     - name: Setup SSH keys for Oracle Linux or Amazon
       authorized_key:
@@ -27,7 +11,26 @@
         key: "{{ lookup('file', 'public_keys') }}"
         state: present
         exclusive: False
-      when: ansible_distribution == "OracleLinux" or ansible_distribution == "Amazon"
+      when:
+        - ansible_os_family == "RedHat"
+        - ansible_distribution not in ["Rocky"]
+
+    - name: Setup SSH keys for Rocky Linux
+      authorized_key:
+        user: rocky
+        key: "{{ lookup('file', 'public_keys') }}"
+        state: present
+        exclusive: False
+      when:
+        - ansible_distribution == "Rocky"
+
+    - name: Setup SSH keys CentOS
+      authorized_key:
+        user: centos
+        key: "{{ lookup('file', 'public_keys') }}"
+        state: present
+        exclusive: False
+      when: ansible_distribution == "CentOS"
 
     - name: Setup SSH keys Debian
       authorized_key:

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -226,7 +226,6 @@
           - make
           - gcc
           - gcc-c++
-          - openssl-devel
           - zlib-devel
           - libzstd-devel
           - lz4

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -226,24 +226,11 @@
           - make
           - gcc
           - gcc-c++
-          - openssl-devel
           - zlib-devel
           - libzstd-devel
           - lz4
           - zstd
         state: present
-      when: ansible_os_family == "RedHat"
-
-    # Installing openssl-devel can transitively upgrade openssl-libs (libcrypto.so.3)
-    # on older OL9 images. That swaps the shared crypto lib out from under the
-    # running sshd, so newly-forked sshd sessions crash during key exchange
-    # ("Connection reset by peer" / scp "Connection closed") and the host becomes
-    # unreachable mid-prepare. Restarting sshd makes it re-exec against the new
-    # libcrypto so subsequent connections work. RedHat-only (Debian is unaffected).
-    - name: Restart sshd after openssl-libs may have been upgraded (RedHat)
-      ansible.builtin.service:
-        name: sshd
-        state: restarted
       when: ansible_os_family == "RedHat"
 
     - name: Install cmake and build tools for Debian family
@@ -345,3 +332,17 @@
         state: latest
         update_cache: yes
       when: ansible_os_family == "Debian"
+
+    # Keep this as the LAST step of the playbook. Installing openssl-devel can
+    # transitively upgrade openssl-libs (libcrypto.so.3) on older OL9 images,
+    # swapping the shared crypto lib out from under the running sshd. Newly-forked
+    # sshd sessions then crash during key exchange ("Connection reset by peer" /
+    # scp "Connection closed") and the host becomes unreachable. By doing it last,
+    # all other prepare tasks have already completed, so a broken connection here
+    # no longer aborts the rest of the playbook. RedHat-only (Debian's libssl-dev
+    # is installed above with the other build tools and does not have this issue).
+    - name: Install openssl-devel for RedHat family (last to avoid sshd disconnect)
+      package:
+        name: openssl-devel
+        state: present
+      when: ansible_os_family == "RedHat"

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -206,7 +206,7 @@
       git:
         repo: https://github.com/Percona-QA/server-qa.git
         dest: /server-qa
-        version: tomislav-pxb-python
+        version: main
         force: yes
 
     - name: Checkout pstress repository

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -5,22 +5,6 @@
   become_method: sudo
   gather_facts: true
   tasks:
-    # DEBUG (PS-11200 oracle-9 hang): launch a detached health sampler that writes
-    # host stats to the serial console every 15s. On the Xen t2 instance the serial
-    # console is the only thing `aws ec2 get-console-output` can still capture after
-    # sshd wedges, so this leaves breadcrumbs (load/mem/disk/dmesg) showing what
-    # kills the host during prepare. Gated to RedHat (oracle-9) only.
-    # REMOVE once the oracle-9 prepare hang is diagnosed.
-    - name: DEBUG start serial-console health sampler (oracle-9 only)
-      ansible.builtin.command: >
-        systemd-run --unit=pxb-debug-breadcrumbs --collect
-        /bin/bash -c 'while true; do
-        { echo "===== $(date -u) ====="; uptime; free -m; df -h /; ss -s; dmesg | tail -n 8; }
-        > /dev/console 2>&1; sleep 15; done'
-      changed_when: false
-      failed_when: false
-      when: ansible_os_family == "RedHat"
-
     - name: Setup SSH keys for RedHat
       authorized_key:
         user: ec2-user

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -5,6 +5,22 @@
   become_method: sudo
   gather_facts: true
   tasks:
+    # DEBUG (PS-11200 oracle-9 hang): launch a detached health sampler that writes
+    # host stats to the serial console every 15s. On the Xen t2 instance the serial
+    # console is the only thing `aws ec2 get-console-output` can still capture after
+    # sshd wedges, so this leaves breadcrumbs (load/mem/disk/dmesg) showing what
+    # kills the host during prepare. Gated to RedHat (oracle-9) only.
+    # REMOVE once the oracle-9 prepare hang is diagnosed.
+    - name: DEBUG start serial-console health sampler (oracle-9 only)
+      ansible.builtin.command: >
+        systemd-run --unit=pxb-debug-breadcrumbs --collect
+        /bin/bash -c 'while true; do
+        { echo "===== $(date -u) ====="; uptime; free -m; df -h /; ss -s; dmesg | tail -n 8; }
+        > /dev/console 2>&1; sleep 15; done'
+      changed_when: false
+      failed_when: false
+      when: ansible_os_family == "RedHat"
+
     - name: Setup SSH keys for RedHat
       authorized_key:
         user: ec2-user

--- a/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/playbooks/prepare.yml
@@ -308,21 +308,27 @@
         update_cache: yes
       when: ansible_os_family == "Debian"
 
-    - name: Install GPG key for EPEL 10
+    # EPEL provides sysbench on RHEL/OL. Enable it for 8/9/10 (not just 10),
+    # otherwise the sysbench install below fails with "No package sysbench
+    # available" on Oracle Linux 9. Amazon Linux is excluded (no matching EPEL
+    # release rpm; major_version there is "2023").
+    - name: Install EPEL GPG key for RedHat family (RHEL/OL 8 and later)
       rpm_key:
         state: present
-        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10
+        key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
       when:
         - ansible_os_family == "RedHat"
-        - ansible_distribution_major_version | int == 10
+        - ansible_distribution != "Amazon"
+        - ansible_distribution_major_version | int >= 8
 
-    - name: Setup EPEL 10 repo
+    - name: Setup EPEL repo for RedHat family (RHEL/OL 8 and later)
       dnf:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
         state: present
       when:
         - ansible_os_family == "RedHat"
-        - ansible_distribution_major_version | int == 10
+        - ansible_distribution != "Amazon"
+        - ansible_distribution_major_version | int >= 8
 
     - name: Install sysbench for RedHat family (RHEL 8 and later)
       dnf:

--- a/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
@@ -307,6 +307,7 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-inc-backup-load/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
+      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
@@ -307,7 +307,6 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-inc-backup-load/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
-      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
@@ -76,6 +76,15 @@
       PS_TARBALL_NAME_MINIMAL: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal.tar.gz"
       PS_TARBALL_NAME_MINIMAL_FOLDER: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal"
 
+  # When PXB_TARBALL_URL is set (job built an unreleased PXB from a branch),
+  # override the REGULAR tarball/folder names with the branch-built artifact so the
+  # download/extract/test steps below transparently use it instead of the released PXB.
+  - name: Override PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+    set_fact:
+      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+
   - name: Extract major version
     set_fact:
       major_version: "{{ PXB_VERSION.split('-')[0] }}"
@@ -282,6 +291,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -290,6 +300,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+
+  - name: Download branch-built PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
+    ansible.builtin.get_url:
+      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      dest: /package-testing/molecule/pxb-new-ps-inc-backup-load/{{ TARBALL_NAME_REGULAR }}
+      mode: '0644'
+    when:
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
+++ b/molecule/pxb-new-ps-inc-backup-load/tasks/main.yml
@@ -56,6 +56,19 @@
       ps_glibc_version: "{{ lookup('env', 'PS_RHEL_GCLIBC_VERSION') }}"
     when: ansible_os_family == "RedHat"
 
+  # For branch builds the job builds two binaries in parallel (oraclelinux:9 and
+  # debian:bookworm) and exports a URL for each. Pick the one built on this host's
+  # OS family so each test host runs a binary linked against its own libraries.
+  - name: Select branch-built PXB tarball URL for RedHat host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_RHEL') }}"
+    when: ansible_os_family == "RedHat"
+
+  - name: Select branch-built PXB tarball URL for Debian host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_DEB') }}"
+    when: ansible_os_family == "Debian"
+
   - name: Set PXB_VERSION and PS_VERSION vars
     set_fact:
       PXB_VERSION: "{{ lookup('env', 'PXB_VERSION') }}"
@@ -79,11 +92,11 @@
   # When PXB_TARBALL_URL is set (job built an unreleased PXB from a branch),
   # override the REGULAR tarball/folder names with the branch-built artifact so the
   # download/extract/test steps below transparently use it instead of the released PXB.
-  - name: Override PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+  - name: Override PXB tarball name when building from a branch (pxb_tarball_url set)
     set_fact:
-      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
-      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
-    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      TARBALL_NAME_REGULAR: "{{ pxb_tarball_url | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (pxb_tarball_url | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract major version
     set_fact:
@@ -291,7 +304,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -300,15 +313,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download branch-built PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
     ansible.builtin.get_url:
-      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      url: "{{ pxb_tarball_url }}"
       dest: /package-testing/molecule/pxb-new-ps-inc-backup-load/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
     when:
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      - pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-innodb-rocksdb/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/playbooks/prepare.yml
@@ -314,21 +314,27 @@
         update_cache: yes
       when: ansible_os_family == "Debian"
 
-    - name: Install GPG key for EPEL 10
+    # EPEL provides sysbench on RHEL/OL. Enable it for 8/9/10 (not just 10),
+    # otherwise the sysbench install below fails with "No package sysbench
+    # available" on Oracle Linux 9. Amazon Linux is excluded (no matching EPEL
+    # release rpm; major_version there is "2023").
+    - name: Install EPEL GPG key for RedHat family (RHEL/OL 8 and later)
       rpm_key:
         state: present
-        key: https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-10
+        key: "https://dl.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-{{ ansible_distribution_major_version }}"
       when:
         - ansible_os_family == "RedHat"
-        - ansible_distribution_major_version | int == 10
+        - ansible_distribution != "Amazon"
+        - ansible_distribution_major_version | int >= 8
 
-    - name: Setup EPEL 10 repo
+    - name: Setup EPEL repo for RedHat family (RHEL/OL 8 and later)
       dnf:
-        name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+        name: "https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm"
         state: present
       when:
         - ansible_os_family == "RedHat"
-        - ansible_distribution_major_version | int == 10
+        - ansible_distribution != "Amazon"
+        - ansible_distribution_major_version | int >= 8
 
     - name: Install sysbench for RedHat family (RHEL 8 and later)
       dnf:

--- a/molecule/pxb-new-ps-innodb-rocksdb/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/playbooks/prepare.yml
@@ -206,7 +206,7 @@
       git:
         repo: https://github.com/Percona-QA/server-qa.git
         dest: /server-qa
-        version: tomislav-pxb-python
+        version: main
         force: yes
 
     - name: Checkout pstress repository

--- a/molecule/pxb-new-ps-innodb-rocksdb/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/playbooks/prepare.yml
@@ -223,13 +223,34 @@
           - make
           - gcc
           - gcc-c++
-          - openssl-devel
           - zlib-devel
           - libzstd-devel
           - lz4
           - zstd
         state: present
       when: ansible_os_family == "RedHat"
+
+    # Pin openssl-devel to the EXACT version already installed as openssl-libs.
+    # On older OL9 AMIs, a plain "openssl-devel" install pulls in a newer
+    # openssl-libs (libcrypto.so.3), swapping the shared crypto lib out from
+    # under the running sshd. New sshd sessions then crash during key exchange
+    # ("Connection reset by peer" / scp "Connection closed") and the host goes
+    # unreachable mid-run (prepare or converge). Installing the matching version
+    # means openssl-libs is already satisfied, so nothing is upgraded and sshd is
+    # never disturbed. RedHat-only (Debian's libssl-dev is unaffected).
+    - name: Gather installed package facts (RedHat)
+      ansible.builtin.package_facts:
+        manager: rpm
+      when: ansible_os_family == "RedHat"
+
+    - name: Install openssl-devel pinned to installed openssl-libs version (RedHat)
+      ansible.builtin.dnf:
+        name: "openssl-devel-{{ ansible_facts.packages['openssl-libs'][0].version }}-{{ ansible_facts.packages['openssl-libs'][0].release }}"
+        state: present
+        allow_downgrade: true
+      when:
+        - ansible_os_family == "RedHat"
+        - "'openssl-libs' in ansible_facts.packages"
 
     - name: Install cmake and build tools for Debian family
       apt:

--- a/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
@@ -307,7 +307,6 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-innodb-rocksdb/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
-      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
@@ -307,6 +307,7 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-innodb-rocksdb/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
+      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
@@ -76,6 +76,15 @@
       PS_TARBALL_NAME_MINIMAL: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal.tar.gz"
       PS_TARBALL_NAME_MINIMAL_FOLDER: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal"
 
+  # When PXB_TARBALL_URL is set (job built an unreleased PXB from a branch),
+  # override the REGULAR tarball/folder names with the branch-built artifact so the
+  # download/extract/test steps below transparently use it instead of the released PXB.
+  - name: Override PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+    set_fact:
+      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+
   - name: Extract major version
     set_fact:
       major_version: "{{ PXB_VERSION.split('-')[0] }}"
@@ -282,6 +291,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -290,6 +300,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+
+  - name: Download branch-built PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
+    ansible.builtin.get_url:
+      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      dest: /package-testing/molecule/pxb-new-ps-innodb-rocksdb/{{ TARBALL_NAME_REGULAR }}
+      mode: '0644'
+    when:
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
+++ b/molecule/pxb-new-ps-innodb-rocksdb/tasks/main.yml
@@ -56,6 +56,19 @@
       ps_glibc_version: "{{ lookup('env', 'PS_RHEL_GCLIBC_VERSION') }}"
     when: ansible_os_family == "RedHat"
 
+  # For branch builds the job builds two binaries in parallel (oraclelinux:9 and
+  # debian:bookworm) and exports a URL for each. Pick the one built on this host's
+  # OS family so each test host runs a binary linked against its own libraries.
+  - name: Select branch-built PXB tarball URL for RedHat host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_RHEL') }}"
+    when: ansible_os_family == "RedHat"
+
+  - name: Select branch-built PXB tarball URL for Debian host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_DEB') }}"
+    when: ansible_os_family == "Debian"
+
   - name: Set PXB_VERSION and PS_VERSION vars
     set_fact:
       PXB_VERSION: "{{ lookup('env', 'PXB_VERSION') }}"
@@ -79,11 +92,11 @@
   # When PXB_TARBALL_URL is set (job built an unreleased PXB from a branch),
   # override the REGULAR tarball/folder names with the branch-built artifact so the
   # download/extract/test steps below transparently use it instead of the released PXB.
-  - name: Override PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+  - name: Override PXB tarball name when building from a branch (pxb_tarball_url set)
     set_fact:
-      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
-      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
-    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      TARBALL_NAME_REGULAR: "{{ pxb_tarball_url | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (pxb_tarball_url | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract major version
     set_fact:
@@ -291,7 +304,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -300,15 +313,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download branch-built PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
     ansible.builtin.get_url:
-      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      url: "{{ pxb_tarball_url }}"
       dest: /package-testing/molecule/pxb-new-ps-innodb-rocksdb/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
     when:
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      - pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-replication/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-replication/playbooks/prepare.yml
@@ -206,7 +206,7 @@
       git:
         repo: https://github.com/Percona-QA/server-qa.git
         dest: /server-qa
-        version: tomislav-pxb-python
+        version: main
         force: yes
 
     - name: Checkout pstress repository

--- a/molecule/pxb-new-ps-replication/tasks/main.yml
+++ b/molecule/pxb-new-ps-replication/tasks/main.yml
@@ -76,6 +76,15 @@
       PS_TARBALL_NAME_MINIMAL: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal.tar.gz"
       PS_TARBALL_NAME_MINIMAL_FOLDER: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal"
 
+  # When PXB_TARBALL_URL is set (job built an unreleased PXB from a branch),
+  # override the REGULAR tarball/folder names with the branch-built artifact so the
+  # download/extract/test steps below transparently use it instead of the released PXB.
+  - name: Override PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+    set_fact:
+      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+
   - name: Extract major version
     set_fact:
       major_version: "{{ PXB_VERSION.split('-')[0] }}"
@@ -282,6 +291,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -290,6 +300,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+
+  - name: Download branch-built PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
+    ansible.builtin.get_url:
+      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      dest: /package-testing/molecule/pxb-new-ps-replication/{{ TARBALL_NAME_REGULAR }}
+      mode: '0644'
+    when:
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-replication/tasks/main.yml
+++ b/molecule/pxb-new-ps-replication/tasks/main.yml
@@ -307,6 +307,7 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-replication/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
+      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-replication/tasks/main.yml
+++ b/molecule/pxb-new-ps-replication/tasks/main.yml
@@ -307,7 +307,6 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-replication/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
-      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-replication/tasks/main.yml
+++ b/molecule/pxb-new-ps-replication/tasks/main.yml
@@ -56,6 +56,19 @@
       ps_glibc_version: "{{ lookup('env', 'PS_RHEL_GCLIBC_VERSION') }}"
     when: ansible_os_family == "RedHat"
 
+  # For branch builds the job builds two binaries in parallel (oraclelinux:9 and
+  # debian:bookworm) and exports a URL for each. Pick the one built on this host's
+  # OS family so each test host runs a binary linked against its own libraries.
+  - name: Select branch-built PXB tarball URL for RedHat host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_RHEL') }}"
+    when: ansible_os_family == "RedHat"
+
+  - name: Select branch-built PXB tarball URL for Debian host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_DEB') }}"
+    when: ansible_os_family == "Debian"
+
   - name: Set PXB_VERSION and PS_VERSION vars
     set_fact:
       PXB_VERSION: "{{ lookup('env', 'PXB_VERSION') }}"
@@ -79,11 +92,11 @@
   # When PXB_TARBALL_URL is set (job built an unreleased PXB from a branch),
   # override the REGULAR tarball/folder names with the branch-built artifact so the
   # download/extract/test steps below transparently use it instead of the released PXB.
-  - name: Override PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+  - name: Override PXB tarball name when building from a branch (pxb_tarball_url set)
     set_fact:
-      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
-      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
-    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      TARBALL_NAME_REGULAR: "{{ pxb_tarball_url | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (pxb_tarball_url | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract major version
     set_fact:
@@ -291,7 +304,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -300,15 +313,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download branch-built PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
     ansible.builtin.get_url:
-      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      url: "{{ pxb_tarball_url }}"
       dest: /package-testing/molecule/pxb-new-ps-replication/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
     when:
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      - pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-upgrade/playbooks/prepare.yml
+++ b/molecule/pxb-new-ps-upgrade/playbooks/prepare.yml
@@ -206,7 +206,7 @@
       git:
         repo: https://github.com/Percona-QA/server-qa.git
         dest: /server-qa
-        version: tomislav-pxb-python
+        version: main
         force: yes
 
     - name: Checkout pstress repository

--- a/molecule/pxb-new-ps-upgrade/tasks/main.yml
+++ b/molecule/pxb-new-ps-upgrade/tasks/main.yml
@@ -312,6 +312,7 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-upgrade/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
+      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 

--- a/molecule/pxb-new-ps-upgrade/tasks/main.yml
+++ b/molecule/pxb-new-ps-upgrade/tasks/main.yml
@@ -56,6 +56,19 @@
       ps_glibc_version: "{{ lookup('env', 'PS_RHEL_GCLIBC_VERSION') }}"
     when: ansible_os_family == "RedHat"
 
+  # For branch builds the job builds two binaries in parallel (oraclelinux:9 and
+  # debian:bookworm) and exports a URL for each. Pick the one built on this host's
+  # OS family so each test host runs a binary linked against its own libraries.
+  - name: Select branch-built PXB tarball URL for RedHat host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_RHEL') }}"
+    when: ansible_os_family == "RedHat"
+
+  - name: Select branch-built PXB tarball URL for Debian host
+    set_fact:
+      pxb_tarball_url: "{{ lookup('env', 'PXB_TARBALL_URL_DEB') }}"
+    when: ansible_os_family == "Debian"
+
   - name: Set PXB_VERSION and PS_VERSION vars
     set_fact:
       PXB_VERSION: "{{ lookup('env', 'PXB_VERSION') }}"
@@ -84,11 +97,11 @@
   # When PXB_TARBALL_URL is set (job built an unreleased NEW PXB from a branch),
   # override the NEW REGULAR tarball/folder names with the branch-built artifact.
   # OLD_PXB_VERSION (TARBALL_NAME_OLD_*) is intentionally left as a released download.
-  - name: Override NEW PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+  - name: Override NEW PXB tarball name when building from a branch (pxb_tarball_url set)
     set_fact:
-      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
-      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
-    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      TARBALL_NAME_REGULAR: "{{ pxb_tarball_url | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (pxb_tarball_url | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract major version
     set_fact:
@@ -296,7 +309,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -305,15 +318,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+      - pxb_tarball_url | default('', true) | length == 0
 
   - name: Download branch-built NEW PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
     ansible.builtin.get_url:
-      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      url: "{{ pxb_tarball_url }}"
       dest: /package-testing/molecule/pxb-new-ps-upgrade/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
     when:
-      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+      - pxb_tarball_url | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-upgrade/tasks/main.yml
+++ b/molecule/pxb-new-ps-upgrade/tasks/main.yml
@@ -81,6 +81,15 @@
       PS_TARBALL_NAME_MINIMAL: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal.tar.gz"
       PS_TARBALL_NAME_MINIMAL_FOLDER: "Percona-Server-{{ lookup('env', 'PS_VERSION') }}-Linux.x86_64.glibc{{ ps_glibc_version }}-minimal"
 
+  # When PXB_TARBALL_URL is set (job built an unreleased NEW PXB from a branch),
+  # override the NEW REGULAR tarball/folder names with the branch-built artifact.
+  # OLD_PXB_VERSION (TARBALL_NAME_OLD_*) is intentionally left as a released download.
+  - name: Override NEW PXB tarball name when building from a branch (PXB_TARBALL_URL set)
+    set_fact:
+      TARBALL_NAME_REGULAR: "{{ lookup('env', 'PXB_TARBALL_URL') | basename }}"
+      TARBALL_NAME_REGULAR_FOLDER: "{{ (lookup('env', 'PXB_TARBALL_URL') | basename) | regex_replace('\\.tar\\.gz$', '') }}"
+    when: lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
+
   - name: Extract major version
     set_fact:
       major_version: "{{ PXB_VERSION.split('-')[0] }}"
@@ -287,6 +296,7 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "80"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
 
   - name: Download {{ TARBALL_NAME_REGULAR }} REGULAR MAIN REPO PS84 PXB 84
     ansible.builtin.get_url:
@@ -295,6 +305,15 @@
       mode: '0644'
     when:
       - lookup('env', 'PXB_RELEASE') == "84"
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length == 0
+
+  - name: Download branch-built NEW PXB tarball from S3 ({{ TARBALL_NAME_REGULAR }})
+    ansible.builtin.get_url:
+      url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
+      dest: /package-testing/molecule/pxb-new-ps-upgrade/{{ TARBALL_NAME_REGULAR }}
+      mode: '0644'
+    when:
+      - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 
   - name: Extract {{ TARBALL_NAME_REGULAR }} REGULAR
     ansible.builtin.unarchive:

--- a/molecule/pxb-new-ps-upgrade/tasks/main.yml
+++ b/molecule/pxb-new-ps-upgrade/tasks/main.yml
@@ -312,7 +312,6 @@
       url: "{{ lookup('env', 'PXB_TARBALL_URL') }}"
       dest: /package-testing/molecule/pxb-new-ps-upgrade/{{ TARBALL_NAME_REGULAR }}
       mode: '0644'
-      follow_redirects: all
     when:
       - lookup('env', 'PXB_TARBALL_URL') | default('', true) | length > 0
 


### PR DESCRIPTION
This change:
- adds a parameter for release branch for PXB
- if release branch is specified then it uses compile pipeline to build PXB from the release branch
- changes the platforms to run the test on to oracle linux 9 and debian 12, since the compile pipeline supports these two and doesn't support some newer